### PR TITLE
Preparation for 0.0.2

### DIFF
--- a/cellophane/src/data.py
+++ b/cellophane/src/data.py
@@ -2,6 +2,7 @@
 
 from attrs import define, field, fields_dict
 from collections import UserDict, UserList
+from collections.abc import KeysView, ValuesView, ItemsView
 from functools import reduce, partial
 from copy import deepcopy
 from pathlib import Path
@@ -65,6 +66,16 @@ class Container(UserDict):
     def _container_attributes(self):
         return [*dir(self), *fields_dict(self.__class__)]
 
+    def keys(self):
+        _fields = {k: None for k in fields_dict(self.__class__) if k != "data"}
+        return KeysView({**self.data, **_fields})
+
+    def values(self):
+        return ValuesView({k: self[k] for k in self.keys()})
+
+    def items(self):
+        return ItemsView({k: self[k] for k in self.keys()})
+
     def __contains__(self, key: Hashable | Sequence[Hashable]) -> bool:
         try:
             self[key]
@@ -79,7 +90,7 @@ class Container(UserDict):
 
         match key:
             case str(k) if k in self._container_attributes:
-                self.__setattr__(k, item)
+                object.__setattr__(self, k, item)
             case *k,:
                 reduce(lambda d, k: d.setdefault(k, Container()), k[:-1], self.data)[
                     k[-1]

--- a/cellophane/src/modules.py
+++ b/cellophane/src/modules.py
@@ -226,12 +226,16 @@ class Hook:
                 queue=log_queue,
             )
             _logger.debug(f"Running {self.label} hook")
+
+            outdir = config.outdir / config.get("outprefix", timestamp)
+
             return self.func(
                 samples=samples,
                 config=config,
                 timestamp=timestamp,
                 logger=_logger,
                 root=root,
+                outdir=outdir,
             )
         else:
             return samples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cellophane"
-version = "0.0.1"
+version = "0.0.2"
 description = "Library for wrappers integrating with SLIMS"
 authors = ["Erik Demitz-Helin <erik.demitz-helin@gu.se>"]
 readme = "README.md"


### PR DESCRIPTION
## Contents
Main reviewer: @octocat

### The What
Various fixes for the 0.0.2 pre-release

### The Why
Some things needed to be changed for the 0.0.2 release.

- Cellophane did not pass outdir and timestamp to hooks. 
- The data.Container class (and derivatives) returned only keys from their underlying .data property.
- Per-job DRMAA2 JobSessions remain until program exits.

### The How
- Cellophane now passes outdir and timestamp to hooks. Note that outdir is the base outdir where runner specific subdirectories are created (i.e. equivalent of outdir.parent in a runner).
- Add keys, values, and items functions to the data.Container class. At his point, I am no longer sure if it needs to inherit from UserDict, as most attributes are overridden.
- DRMAA2 JobSessions are now destroyed on job completion. There is most likely a more intelligent way of handling this (perhaps in a global scope), but for now this might reduce the spam a bit.

### This [update](https://semver.org/) is:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Verifications
- [ ] Code reviewed by @octocat
