### PR TITLE
feat: Add 'skip' type parameter

### DIFF
--- a/cellophane/src/cfg.py
+++ b/cellophane/src/cfg.py
@@ -41,6 +41,8 @@ def _set_type(cls, properties, instance, schema):
             match subschema["type"] if "type" in subschema else None:
                 case "boolean":
                     instance[property] = bool(instance[property])
+                case "skip":
+                    instance[property] = bool(instance[property])
                 case "path":
                     instance[property] = Path(instance[property])
                 case "string":
@@ -111,6 +113,8 @@ def _get_schema_properties(cls, properties, instance, schema, flag_mapping):
             case {"enum": enum}:
                 flag_mapping[*_key].append(click.Choice(enum, case_sensitive=False))
             case {"type": "boolean"}:
+                flag_mapping[*_key].append(bool)
+            case {"type": "skip"}:
                 flag_mapping[*_key].append(bool)
             case {"type": "skip"}:
                 flag_mapping[*_key].append(bool)


### PR DESCRIPTION
## Contents

Adds back support for the 'skip' type, allowing for marking an entire section of the config schema as optional. Other than that it behaves just like a boolean.