### PR TITLE
feat: Various executor tweaks

### DIFF
--- a/cellophane/__init__.py
+++ b/cellophane/__init__.py
@@ -232,6 +232,7 @@ def cellophane(
             logger.debug(f"Found {len(executors_)} executors")
 
             executor_cls = next(e for e in executors_ if e.name == config.executor.name)
+            executors.EXECUTOR = executor_cls
             logger.debug(f"Using {executor_cls.name} executor")
 
             config.analysis = label  # type: ignore[attr-defined]

--- a/cellophane/src/executors.py
+++ b/cellophane/src/executors.py
@@ -131,6 +131,7 @@ class Executor:
             for job in self.jobs.values():
                 job.join()
 
+EXECUTOR: type[Executor] = Executor
 
 @define(slots=False)
 class SubprocesExecutor(Executor, name="subprocess"):

--- a/cellophane/src/modules.py
+++ b/cellophane/src/modules.py
@@ -110,7 +110,7 @@ class Runner:
                 logger=logger,
                 root=root,
                 workdir=workdir,
-                executor=executor_cls(config=config),
+                executor=executor_cls(config=config, log_queue=log_queue),
             ):
                 case None:
                     logger.debug("Runner did not return any samples")
@@ -190,6 +190,7 @@ class Hook:
         config: cfg.Config,
         root: Path,
         executor_cls: type[executors.Executor],
+        log_queue: Queue,
     ) -> data.Samples:
         logger = logging.LoggerAdapter(logging.getLogger(), {"label": self.label})
         logger.debug(f"Running {self.label} hook")
@@ -201,8 +202,8 @@ class Hook:
             logger=logger,
             root=root,
             workdir=config.workdir / config.tag,
-            executor=executor_cls(config=config)
-
+            executor=executor_cls(config=config, log_queue=log_queue),
+            log_queue=log_queue,
         ):
             case returned if isinstance(returned, data.Samples):
                 _ret = returned

--- a/tests/lib/integration/good_executor.yaml
+++ b/tests/lib/integration/good_executor.yaml
@@ -1,0 +1,40 @@
+structure:
+  modules:
+    dummy.py: |
+      from cellophane import modules, executors
+
+      class TestExecutor(executors.Executor, name="DUMMY"):
+          def target(**_):
+              pass
+
+      @modules.pre_hook()
+      def runner_a(logger, samples, executor, **_):
+          logger.info(f"HOOK - {executor.name=}")
+          logger.info(f"HOOK - {executors.EXECUTOR.name=}")
+          return samples
+      
+      @modules.runner()
+      def runner_b(logger, samples, executor, **_):
+          logger.info(f"RUNNER - {executor.name=}")
+          logger.info(f"RUNNER - {executors.EXECUTOR.name=}")
+          return samples
+
+  samples.yaml: |
+    - id: a
+      files:
+      - input/a.txt
+  input:
+    a.txt: "INPUT_A"
+
+args:
+  --samples_file: samples.yaml
+  --executor_name: DUMMY
+  --workdir: out
+
+logs:
+- Using DUMMY executor
+- HOOK - executor.name='DUMMY'
+- HOOK - executors.EXECUTOR.name='DUMMY'
+- RUNNER - executor.name='DUMMY'
+- RUNNER - executors.EXECUTOR.name='DUMMY'
+exception: null

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -1,3 +1,4 @@
+import multiprocessing as mp
 import time
 from unittest.mock import MagicMock
 
@@ -7,14 +8,14 @@ from cellophane import executors
 class Test_SubprocessExecutor:
     def test_executor(self, tmp_path):
         config = MagicMock(workdir=tmp_path, logdir=tmp_path)
-        spe = executors.SubprocesExecutor(config=config)
+        spe = executors.SubprocesExecutor(config=config, log_queue=mp.Queue())
         proc, _ = spe.submit("sleep .2", name="sleep", wait=True)
         assert not proc.is_alive()
         assert proc.exitcode == 0
 
     def test_executor_terminate(self, tmp_path):
         config = MagicMock(workdir=tmp_path, logdir=tmp_path)
-        spe = executors.SubprocesExecutor(config=config)
+        spe = executors.SubprocesExecutor(config=config, log_queue=mp.Queue())
         proc, uuid = spe.submit("sleep 1", name="sleep")
         time.sleep(.1)
         assert proc.is_alive()
@@ -25,7 +26,7 @@ class Test_SubprocessExecutor:
 
     def test_executor_terminate_all(self, tmp_path):
         config = MagicMock(workdir=tmp_path, logdir=tmp_path)
-        spe = executors.SubprocesExecutor(config=config)
+        spe = executors.SubprocesExecutor(config=config, log_queue=mp.Queue())
         procs = [
             spe.submit("sleep 1", name="sleep")[0],
             spe.submit("sleep 1", name="sleep")[0],


### PR DESCRIPTION
## Contents

### The What
- Properly setup queue logging in executors
- Set cellophane.executors.EXECUTOR to the active implementation at runtime

### The Why
- Fixes logging from executors
- Allows modules without hooks/runners to reference the active executor implementation 

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
