### PR TITLE
refactor(!): Use WorkerPool for task submission

### DIFF
--- a/cellophane/src/executors.py
+++ b/cellophane/src/executors.py
@@ -7,13 +7,14 @@ import shlex
 import subprocess as sp
 import sys
 from pathlib import Path
-from signal import SIGTERM, signal
 from typing import Any, Callable, ClassVar
 from uuid import UUID, uuid4
 
+import psutil
 from attrs import define, field
 from mpire import WorkerPool
 from mpire.async_result import AsyncResult
+from mpire.exception import InterruptWorker
 
 from . import cfg, logs
 
@@ -67,20 +68,34 @@ class Executor:
         logger = logging.LoggerAdapter(logging.getLogger(), {"label": name})
         _uuid = uuid or uuid4()
 
-        def _terminate_hook(*args: Any, **kwargs: Any) -> None:
-            del args, kwargs  # Unused
-            nonlocal logger, _uuid
-            code = self.terminate_hook(_uuid, logger)
-            raise SystemExit(code or 143)
+        def _callback(result: AsyncResult) -> None:
+            logger.debug("Command completed successfully")
+            if callback:
+                try:
+                    callback(result)
+                except Exception as exc:  # pylint: disable=broad-except
+                    logger.error(f"Callback failed: {exc!r}")
 
-        def _target(shared) -> None:
+        def _error_callback(exception: Exception) -> None:
+            logger.error(f"Command failed: {exception!r}")
+            if error_callback:
+                try:
+                    error_callback(exception)
+                except Exception as exc:  # pylint: disable=broad-except
+                    logger.error(f"Error callback failed: {exc!r}")
+
+        def _target(shared: tuple[mp.Queue, cfg.Config, Callable, Callable], *, uuid: UUID) -> None:
             sys.stdout = sys.stderr = open(os.devnull, "w", encoding="utf-8")
             log_queue, config, target, terminate_hook = shared
             logs.setup_queue_logging(log_queue)
             logger = logging.LoggerAdapter(logging.getLogger(), {"label": name})
             _workdir = workdir or config.workdir / _uuid.hex
             _workdir.mkdir(parents=True, exist_ok=True)
-            signal(SIGTERM, terminate_hook)
+
+            def _terminate_hook(*args: Any, **kwargs: Any) -> None:
+                del args, kwargs  # Unused
+                code = terminate_hook(uuid, logger)
+                raise SystemExit(code or 143)
 
             try:
                 target(
@@ -94,28 +109,30 @@ class Executor:
                     cpus=cpus or config.executor.cpus,
                     memory=memory or config.executor.memory,
                 )
+            except InterruptWorker:
+                logger.warning(f"Terminating job with uuid {_uuid}")
+                _terminate_hook()
             except SystemExit as exc:
                 if exc.code != 0:
-                    logger.error(f"{args} failed with exit code {exc.code}")
-                    raise SystemExit(exc.code) from exc
+                    logger.warning(f"Command failed with exit code: {exc.code}")
+                    exit(exc.code)
             except Exception as exc:  # pylint: disable=broad-except
-                logger.error(f"{args} failed with exception {exc}")
-                raise SystemExit(1) from exc
-
-            logger.debug(f"{args} completed successfully")
+                logger.warning(f"Command failed with exception: {exc!r}")
+                exit(1)
 
         self.pool.set_shared_objects(
             (
                 self.log_queue,
                 self.config,
                 self.target,
-                _terminate_hook
+                self.terminate_hook
             ))
 
         result = self.pool.apply_async(
             func=_target,
-            callback=callback,
-            error_callback=error_callback,
+            kwargs={"uuid": _uuid},
+            callback=_callback,
+            error_callback=_error_callback,
         )
         self.jobs[_uuid] = result
 
@@ -179,7 +196,7 @@ class SubprocesExecutor(Executor, name="subprocess"):
             proc = sp.Popen(
                 shlex.join(args),
                 cwd=workdir,
-                env=env or {} | ({**os.environ} if os_env else {}),
+                env=env | ({**os.environ} if os_env else {}),
                 shell=True,
                 stdout=stdout,
                 stderr=stderr,
@@ -191,15 +208,20 @@ class SubprocesExecutor(Executor, name="subprocess"):
             logger.debug(
                 f"Child process (pid={proc.pid}) exited with code {proc.returncode}"
             )
-            raise SystemExit(self.procs[uuid].returncode)
+            exit(self.procs[uuid].returncode)
 
     def terminate_hook(self, uuid: UUID, logger: logging.LoggerAdapter) -> int | None:
         if uuid in self.procs:
-            proc = self.procs[uuid]
-            logger.warning(f"Terminating child process (pid={proc.pid})")
-            self.procs[uuid].send_signal(SIGTERM)
-            pid, code = os.waitpid(self.procs[uuid].pid, 0)
-            logger.debug(f"Child process (pid={pid}) exited with code {code}")
+            proc = psutil.Process(self.procs[uuid].pid)
+            children = proc.children(recursive=True)
+            logger.warning(f"Terminating process (pid={proc.pid})")
+            proc.terminate()
+            code = int(proc.wait())
+            logger.debug(f"Process (pid={proc.pid}) exited with code {code}")
+            for child in children:
+                logger.warning(f"Terminating orphan process (pid={child.pid})")
+                child.terminate()
+            psutil.wait_procs(children)
             return code
         else:
             return None

--- a/cellophane/src/executors.py
+++ b/cellophane/src/executors.py
@@ -12,6 +12,8 @@ from typing import Any, Callable, ClassVar
 from uuid import UUID, uuid4
 
 from attrs import define, field
+from mpire import WorkerPool
+from mpire.async_result import AsyncResult
 
 from . import cfg, logs
 
@@ -22,16 +24,28 @@ class Executor:
 
     name: ClassVar[str]
     config: cfg.Config
+    pool: WorkerPool
     log_queue: mp.Queue
-    jobs: dict[UUID, mp.Process] = field(factory=dict, init=False)
+    jobs: dict[UUID, AsyncResult] = field(factory=dict, init=False)
 
     def __init_subclass__(cls, *args: Any, name: str, **kwargs: Any) -> None:
         """Register the class in the registry."""
         super().__init_subclass__(*args, **kwargs)
         cls.name = name or cls.__name__.lower()
 
-    def target(self, *args: Any, **kwargs: Any) -> int | None:  # pragma: no cover
-        del args, kwargs  # Unused
+    def target(
+        self,
+        *,
+        name: str,
+        uuid: UUID,
+        workdir: Path,
+        env: dict,
+        os_env: bool,
+        logger: logging.LoggerAdapter,
+        cpus: int,
+        memory: int,
+    ) -> int | None:  # pragma: no cover
+        del name, uuid, workdir, env, os_env, logger, cpus, memory  # Unused
         raise NotImplementedError
 
     def submit(
@@ -47,62 +61,68 @@ class Executor:
         error_callback: Callable | None = None,
         cpus: int | None = None,
         memory: int | None = None,
-    ) -> tuple[mp.Process, UUID]:
+    ) -> tuple[AsyncResult, UUID]:
         """Submit a job."""
 
         logger = logging.LoggerAdapter(logging.getLogger(), {"label": name})
         _uuid = uuid or uuid4()
-        
+
         def _terminate_hook(*args: Any, **kwargs: Any) -> None:
             del args, kwargs  # Unused
             nonlocal logger, _uuid
             code = self.terminate_hook(_uuid, logger)
             raise SystemExit(code or 143)
 
-        def _target() -> None:
+        def _target(shared) -> None:
             sys.stdout = sys.stderr = open(os.devnull, "w", encoding="utf-8")
-            logs.setup_queue_logging(self.log_queue)
+            log_queue, config, target, terminate_hook = shared
+            logs.setup_queue_logging(log_queue)
             logger = logging.LoggerAdapter(logging.getLogger(), {"label": name})
-            _workdir = workdir or self.config.workdir / _uuid.hex
+            _workdir = workdir or config.workdir / _uuid.hex
             _workdir.mkdir(parents=True, exist_ok=True)
-            _args = [word for arg in args for word in shlex.split(str(arg))]
-            _env = {k: str(v) for k, v in env.items()} if env else {}
-            _cpus = cpus or self.config.executor.cpus
-            _memory = memory or self.config.executor.memory
-            signal(SIGTERM, _terminate_hook)
+            signal(SIGTERM, terminate_hook)
 
             try:
-                self.target(
-                    *_args,
+                target(
+                    *(word for arg in args for word in shlex.split(str(arg))),
                     name=name,
                     uuid=_uuid,
                     workdir=_workdir,
-                    env=_env,
+                    env={k: str(v) for k, v in env.items()} if env else {},
                     os_env=os_env,
                     logger=logger,
-                    cpus=_cpus,
-                    memory=_memory,
+                    cpus=cpus or config.executor.cpus,
+                    memory=memory or config.executor.memory,
                 )
+            except SystemExit as exc:
+                if exc.code != 0:
+                    logger.error(f"{args} failed with exit code {exc.code}")
+                    raise SystemExit(exc.code) from exc
             except Exception as exc:  # pylint: disable=broad-except
                 logger.error(f"{args} failed with exception {exc}")
-                (_workdir / "error").touch()
-                _callback = error_callback or (lambda: None)
-            else:
-                logger.debug(f"{args} completed successfully")
-                _callback = callback or (lambda: None)
+                raise SystemExit(1) from exc
 
-            try:
-                _callback()
-            except Exception as exc:  # pylint: disable=broad-except
-                logger.error(f"Callback failed with exception {exc}")
+            logger.debug(f"{args} completed successfully")
 
-        proc = mp.Process(target=_target)
-        self.jobs[_uuid] = proc
-        proc.start()
+        self.pool.set_shared_objects(
+            (
+                self.log_queue,
+                self.config,
+                self.target,
+                _terminate_hook
+            ))
+
+        result = self.pool.apply_async(
+            func=_target,
+            callback=callback,
+            error_callback=error_callback,
+        )
+        self.jobs[_uuid] = result
 
         if wait:
-            proc.join()
-        return proc, _uuid
+            result.wait()
+
+        return result, _uuid
 
     def terminate_hook(self, uuid: UUID, logger: logging.LoggerAdapter) -> int | None:
         """Hook to be called prior to job termination.
@@ -117,23 +137,20 @@ class Executor:
         del uuid, logger  # Unused
         return 143  # SIGTERM
 
-    def terminate(self, uuid: UUID | None = None) -> None:
-        """Terminating a specific job or all jobs."""
-        if uuid in self.jobs:
-            self.jobs[uuid].terminate()
-        elif uuid is None:
-            for job in self.jobs.values():
-                job.terminate()
+    def terminate(self) -> None:
+        """Terminate all jobs."""
+        self.pool.terminate()
 
-    def join(self, uuid: UUID | None = None) -> None:
+    def wait(self, uuid: UUID | None = None) -> None:
         """Wait for a specific job or all jobs to complete."""
         if uuid in self.jobs:
-            self.jobs[uuid].join()
+            self.jobs[uuid].wait()
         elif uuid is None:
-            for job in self.jobs.values():
-                job.join()
+            self.pool.stop_and_join(keep_alive=True)
+
 
 EXECUTOR: type[Executor] = Executor
+
 
 @define(slots=False)
 class SubprocesExecutor(Executor, name="subprocess"):
@@ -157,7 +174,7 @@ class SubprocesExecutor(Executor, name="subprocess"):
 
         with (
             open(logdir / f"{uuid.hex}.out", "w", encoding="utf-8") as stdout,
-            open(logdir / f"{uuid.hex}.err", "w", encoding="utf-8") as stderr
+            open(logdir / f"{uuid.hex}.err", "w", encoding="utf-8") as stderr,
         ):
             proc = sp.Popen(
                 shlex.join(args),

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -2,38 +2,69 @@ import multiprocessing as mp
 import time
 from unittest.mock import MagicMock
 
-from cellophane import executors
+from mpire import WorkerPool
+
+from cellophane import data, executors
 
 
 class Test_SubprocessExecutor:
     def test_executor(self, tmp_path):
-        config = MagicMock(workdir=tmp_path, logdir=tmp_path)
-        spe = executors.SubprocesExecutor(config=config, log_queue=mp.Queue())
-        proc, _ = spe.submit("sleep .2", name="sleep", wait=True)
-        assert not proc.is_alive()
-        assert proc.exitcode == 0
+        config = data.Container(workdir=tmp_path, logdir=tmp_path, executor={"cpus": 1, "memory": 1})
+        with WorkerPool(
+            daemon=False,
+            use_dill=True,
+        ) as pool:
+            spe = executors.SubprocesExecutor(
+                config=config,
+                pool=pool,
+                log_queue=mp.Queue(),
+            )
 
-    def test_executor_terminate(self, tmp_path):
-        config = MagicMock(workdir=tmp_path, logdir=tmp_path)
-        spe = executors.SubprocesExecutor(config=config, log_queue=mp.Queue())
-        proc, uuid = spe.submit("sleep 1", name="sleep")
-        time.sleep(.1)
-        assert proc.is_alive()
-        spe.terminate(uuid)
-        spe.join(uuid)
-        assert not proc.is_alive()
-        assert proc.exitcode == 15  # SIGTERM
+            result, _ = spe.submit("sleep .2", name="sleep", wait=True)
+
+            assert result.ready()
+            assert result.successful()
+
+    def test_callback(self, tmp_path):
+        config = data.Container(workdir=tmp_path, logdir=tmp_path, executor={"cpus": 1, "memory": 1})
+        with WorkerPool(
+            daemon=False,
+            use_dill=True,
+        ) as pool:
+            spe = executors.SubprocesExecutor(
+                config=config,
+                pool=pool,
+                log_queue=mp.Queue(),
+            )
+            _callback = MagicMock()
+            _error_callback = MagicMock()
+            assert not _callback.called
+            assert not _error_callback.called
+            spe.submit("sleep 0", name="sleep", wait=True, callback=_callback, error_callback=_error_callback)
+            assert _callback.called
+            assert not _error_callback.called
+            spe.submit("exit 42", name="exception", wait=True, callback=_callback, error_callback=_error_callback)
+            assert _error_callback.called
+
 
     def test_executor_terminate_all(self, tmp_path):
-        config = MagicMock(workdir=tmp_path, logdir=tmp_path)
-        spe = executors.SubprocesExecutor(config=config, log_queue=mp.Queue())
-        procs = [
-            spe.submit("sleep 1", name="sleep")[0],
-            spe.submit("sleep 1", name="sleep")[0],
-            spe.submit("sleep 1", name="sleep")[0],
-        ]
-        time.sleep(.1)
-        assert all(p.is_alive() for p in procs)
-        spe.terminate()
-        spe.join()
-        assert not any(p.is_alive() for p in procs)
+        config = data.Container(workdir=tmp_path, logdir=tmp_path, executor={"cpus": 1, "memory": 1})
+        with WorkerPool(
+            daemon=False,
+            use_dill=True,
+        ) as pool:
+            spe = executors.SubprocesExecutor(
+                config=config,
+                pool=pool,
+                log_queue=mp.Queue(),
+            )
+            results = [
+                spe.submit("sleep 1", name="sleep")[0],
+                spe.submit("sleep 1", name="sleep")[0],
+                spe.submit("sleep 1", name="sleep")[0],
+            ]
+            time.sleep(0.1)
+            assert not any(r.ready() for r in results), [r.get() for r in results]
+            spe.terminate()
+            spe.wait()
+            assert all(r.ready() for r in results)


### PR DESCRIPTION
## Contents
Review deadline:

### The What

Use a `WorkerPool` for task submission and handle termination gracefully.

### The Why

Previously callbacks were executed in the workers, preventing changes to runner/hook local variables. The termination hooks were also buggy, and probably didn't run as expected.

### The How

Spins up a WorkerPool on hook/runner startup and passes it to the executor. This is mostly compatible with the old behavior, except for `Executor.submit` which now returns a `AsyncResult` instead of an ``mp.Process`. The ability to stop individual executor jobs has also been removed.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
