### PR TITLE
feat: Per sample/runner hooks

### DIFF
--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -175,6 +175,7 @@ def _main(
     samples = run_hooks(
         hooks,
         when="pre",
+        per="session",
         samples=samples,
         log_queue=log_queue,
         config=config,
@@ -204,6 +205,7 @@ def _main(
             executor_cls=executor_cls,
             timestamp=timestamp,
             cleaner=cleaner,
+            hooks=hooks,
         )
         | samples.failed
     )
@@ -212,6 +214,7 @@ def _main(
     samples = run_hooks(
         hooks,
         when="post",
+        per="session",
         samples=samples,
         config=config,
         log_queue=log_queue,

--- a/src/cellophane/data/samples.py
+++ b/src/cellophane/data/samples.py
@@ -359,7 +359,7 @@ class Samples(UserList[S]):
         return self
 
     def __xor__(self, other: "Samples") -> "Samples":
-        """Replace all attributes nd samples in 'self' with those from 'other', effectively
+        """Replace all attributes and samples in 'self' with those from 'other', effectively
         replacing 'self' with a copy of 'other'.
         """
         samples = deepcopy(self)
@@ -541,9 +541,10 @@ class Samples(UserList[S]):
             Class: A new instance of the class with only the samples with files.
 
         """
-        return self.__class__(
-            [sample for sample in self if sample.files and all(Path(f).exists() for f in sample.files)]
-        )
+        instance = deepcopy(self)
+        instance.data = [sample for sample in self if sample.files and all(Path(f).exists() for f in sample.files)]
+
+        return instance
 
     @property
     def without_files(self) -> "Samples":
@@ -554,9 +555,10 @@ class Samples(UserList[S]):
             Class: A new instance of the class with only the samples without files.
 
         """
-        return self.__class__(
-            [sample for sample in self if not sample.files or any(not Path(f).exists() for f in sample.files)]
-        )
+        instance = deepcopy(self)
+        instance.data = [sample for sample in self if not sample.files or any(not Path(f).exists() for f in sample.files)]
+
+        return instance
 
     @property
     def complete(self) -> "Samples":
@@ -570,10 +572,10 @@ class Samples(UserList[S]):
             Class: A new instance of the class with only the completed samples.
 
         """
-        return self.__class__(
-            [sample for sample in self if sample.processed and not sample.failed],
-            output=self.output,
-        )
+        instance = deepcopy(self)
+        instance.data = [sample for sample in self if sample.processed and not sample.failed]
+
+        return instance
 
     @property
     def unprocessed(self) -> "Samples":
@@ -587,10 +589,10 @@ class Samples(UserList[S]):
             Class: A new instance of the class with only the completed samples.
 
         """
-        return self.__class__(
-            [sample for sample in self if not sample.failed and not sample.processed],
-            output=self.output,
-        )
+        instance = deepcopy(self)
+        instance.data = [sample for sample in self if not sample.failed and not sample.processed]
+
+        return instance
 
     @property
     def failed(self) -> "Samples":
@@ -604,4 +606,7 @@ class Samples(UserList[S]):
             Class: A new instance of the class with only the failed samples.
 
         """
-        return self.__class__([sample for sample in self if sample.failed])
+        instance = deepcopy(self)
+        instance.data = [sample for sample in self if sample.failed]
+
+        return instance

--- a/src/cellophane/modules/callbacks.py
+++ b/src/cellophane/modules/callbacks.py
@@ -1,0 +1,129 @@
+"""Callbacks for runners and hooks executed as jobs"""
+
+import time
+from functools import partial
+from logging import LoggerAdapter, getLogger
+from multiprocessing import Queue
+from multiprocessing.synchronize import Lock as LockType
+from pathlib import Path
+from typing import Sequence
+from uuid import UUID
+
+from mpire import WorkerPool
+
+from cellophane.cfg import Config
+from cellophane.cleanup import Cleaner, DeferredCleaner
+from cellophane.data import Samples
+from cellophane.executors import Executor
+from cellophane.logs import handle_warnings, redirect_logging_to_queue
+
+from .hook import Hook, run_hooks
+
+
+def _run_per_sample_hooks(
+    log_queue: Queue,
+    *,
+    log_label: str,
+    hooks: Sequence[Hook],
+    samples: Samples,
+    config: Config,
+    root: Path,
+    executor_cls: type[Executor],
+    timestamp: time.struct_time,
+) -> tuple[Samples, DeferredCleaner]:
+    handle_warnings()
+    redirect_logging_to_queue(log_queue)
+    logger = LoggerAdapter(getLogger(), {"label": log_label})
+    cleaner = DeferredCleaner(root=root)
+
+    _samples = run_hooks(
+        hooks,
+        when="post",
+        per="sample",
+        samples=samples,
+        config=config,
+        root=root,
+        executor_cls=executor_cls,
+        log_queue=log_queue,
+        timestamp=timestamp,
+        cleaner=cleaner,
+        logger=logger,
+    )
+
+    return _samples, cleaner
+
+
+def _hook_callback(
+    result: tuple[Samples, DeferredCleaner],
+    *,
+    samples: Samples,
+    logger: LoggerAdapter,
+    cleaner: Cleaner,
+) -> None:
+    try:
+        cleaner &= result[1]
+    except Exception as exc:
+        logger.error(f"Exception when merging cleaners: {exc!r}", exc_info=True)
+
+    samples |= result[0]
+
+
+
+def runner_callback(
+    result: tuple[Samples, DeferredCleaner],
+    *,
+    logger: LoggerAdapter,
+    samples: Samples,
+    cleaner: Cleaner,
+    pool: WorkerPool,
+    sample_runner_count: dict[UUID, int],
+    hooks: Sequence[Hook],
+    config: Config,
+    root: Path,
+    executor_cls: type[Executor],
+    timestamp: time.struct_time,
+    lock: LockType,
+) -> None:
+    try:
+        cleaner &= result[1]
+    except Exception as exc:
+        logger.error(f"Exception when merging cleaners: {exc!r}", exc_info=True)
+
+    if len(samples) == 0:
+        # No samples have been returned yet, so do an in-place copy of the result samples into 'samples'
+        samples ^= result[0]
+    else:
+        try:
+            samples &= result[0]
+        except Exception as exc:
+            _msg = f"Exception when merging samples: {exc!r}"
+            logger.error(_msg, exc_info=True)
+            for sample in result[0]:
+                if sample.uuid not in samples:
+                    samples.append(sample)
+                samples[sample.uuid].fail(_msg)
+
+    for uuid, sample in ((u, s) for u, s in samples.split() if u in result[0]):
+        sample_runner_count[uuid] -= 1
+        if sample_runner_count[uuid] == 0:
+            _log_label = (logger.extra or {"label": "cellophane"})["label"]
+
+            pool.apply_async(
+                _run_per_sample_hooks,
+                kwargs={
+                    "log_label": _log_label,
+                    "hooks": hooks,
+                    "samples": sample,
+                    "config": config,
+                    "root": root,
+                    "executor_cls": executor_cls,
+                    "timestamp": timestamp,
+                },
+                callback=partial(
+                    _hook_callback,
+                    samples=samples,
+                    logger=logger,
+                    cleaner=cleaner,
+                )
+            )
+    lock.release()

--- a/src/cellophane/modules/callbacks.py
+++ b/src/cellophane/modules/callbacks.py
@@ -16,6 +16,7 @@ from cellophane.cleanup import Cleaner, DeferredCleaner
 from cellophane.data import Samples
 from cellophane.executors import Executor
 from cellophane.logs import handle_warnings, redirect_logging_to_queue
+from cellophane.util import Timestamp
 
 from .hook import Hook, run_hooks
 
@@ -29,7 +30,7 @@ def _run_per_sample_hooks(
     config: Config,
     root: Path,
     executor_cls: type[Executor],
-    timestamp: time.struct_time,
+    timestamp: Timestamp,
 ) -> tuple[Samples, DeferredCleaner]:
     handle_warnings()
     redirect_logging_to_queue(log_queue)
@@ -48,6 +49,7 @@ def _run_per_sample_hooks(
         timestamp=timestamp,
         cleaner=cleaner,
         logger=logger,
+        checkpoint_suffix=f"sample_{samples[0].id}"
     )
 
     return _samples, cleaner

--- a/src/cellophane/modules/decorators.py
+++ b/src/cellophane/modules/decorators.py
@@ -96,6 +96,7 @@ def runner(
 
 def pre_hook(
     label: str | None = None,
+    per: Literal["session", "runner"] = "session",
     before: DEPENDENCY_TYPE = None,
     after: DEPENDENCY_TYPE = None,
 ) -> Callable:
@@ -121,6 +122,7 @@ def pre_hook(
             func=func,
             when="pre",
             condition="always",
+            per=per if per in ("session", "runner") else "session",
             before=before,
             after=after,
         )
@@ -131,6 +133,7 @@ def pre_hook(
 def post_hook(
     label: str | None = None,
     condition: Literal["always", "complete", "failed"] = "always",
+    per: Literal["session", "sample", "runner"] = "session",
     before: DEPENDENCY_TYPE = None,
     after: DEPENDENCY_TYPE = None,
 ) -> Callable:
@@ -145,6 +148,12 @@ def post_hook(
             - "complete": The post-hook will recieve only completed samples.
             - "failed": The post-hook will recieve only failed samples.
             Defaults to "always".
+        per (Literal["session", "sample", "runner"]): The level at which the hook
+            will be executed.
+            - "session": The hook will be executed after all runners are complete.
+            - "sample": The hook will be executed when all runners finish processing
+                an individual sample.
+            - "runner": The hook will be executed upon completion of a single runner.
         before (list[str] | Literal["all"] | None): List of post-hooks guaranteed to
             execute after the resulting pre-hook. Defaults to an empty list.
         after (list[str] | Literal["all"] | None): List of post-hooks guaratneed to
@@ -164,6 +173,7 @@ def post_hook(
             func=func,
             when="post",
             condition=condition,
+            per=per if per in ("session", "sample", "runner") else "session",
             before=before,
             after=after,
         )

--- a/src/cellophane/modules/runner_.py
+++ b/src/cellophane/modules/runner_.py
@@ -1,11 +1,13 @@
 """Runners for executing functions as jobs."""
 
 import time
-from functools import partial, reduce
+from functools import partial
 from logging import LoggerAdapter, getLogger
-from multiprocessing import Queue
+from multiprocessing import Lock, Queue
+from multiprocessing.synchronize import Lock as LockType
 from pathlib import Path
 from typing import Callable, Sequence
+from uuid import UUID
 
 from mpire import WorkerPool
 from mpire.exception import InterruptWorker
@@ -18,7 +20,9 @@ from cellophane.executors import Executor
 from cellophane.logs import handle_warnings, redirect_logging_to_queue
 from cellophane.util import Timestamp
 
+from .callbacks import runner_callback
 from .checkpoint import Checkpoints
+from .hook import Hook, run_hooks
 
 
 class Runner:
@@ -63,7 +67,8 @@ class Runner:
         executor_cls: type[Executor],
         timestamp: Timestamp,
         workdir: Path,
-        checkpoints: Checkpoints | None = None,
+        hooks: Sequence[Hook],
+        checkpoints: Checkpoints,
     ) -> tuple[Samples, DeferredCleaner]:
         handle_warnings()
         redirect_logging_to_queue(log_queue)
@@ -71,6 +76,20 @@ class Runner:
         workdir.mkdir(parents=True, exist_ok=True)
         logger = LoggerAdapter(getLogger(), {"label": self.label})
         cleaner = DeferredCleaner(root=workdir)
+
+        samples = run_hooks(
+            hooks,
+            when="pre",
+            per="runner",
+            samples=samples,
+            config=config,
+            root=root,
+            executor_cls=executor_cls,
+            log_queue=log_queue,
+            timestamp=timestamp,
+            cleaner=cleaner,
+            logger=logger,
+        )
 
         with executor_cls(
             config=config,
@@ -139,6 +158,20 @@ class Runner:
         for sample in samples.failed:
             logger.debug(f"Sample {sample.id} failed - {sample.failed}")
 
+        samples = run_hooks(
+            hooks,
+            when="post",
+            per="runner",
+            samples=samples,
+            config=config,
+            root=root,
+            executor_cls=executor_cls,
+            log_queue=log_queue,
+            timestamp=timestamp,
+            cleaner=cleaner,
+            logger=logger,
+        )
+
         return samples, cleaner
 
 
@@ -189,10 +222,10 @@ def _cleanup(
             proc.kill()
             proc.wait()
 
-
 def start_runners(
     *,
     runners: Sequence[Runner],
+    hooks: Sequence[Hook],
     samples: Samples,
     logger: LoggerAdapter,
     log_queue: Queue,
@@ -227,6 +260,10 @@ def start_runners(
             sample.fail("Sample was not processed")
         return samples
 
+    result_samples = samples.__class__()
+    sample_runner_count: dict[UUID, int] = {}
+    callback_locks: list[LockType] = []
+
     with WorkerPool(
         use_dill=True,
         daemon=False,
@@ -234,8 +271,7 @@ def start_runners(
         shared_objects=log_queue,
     ) as pool:
         try:
-            results = []
-            samples_: Samples
+
             for runner_, group, samples_ in (
                 (r, g, s)
                 for r in runners
@@ -246,8 +282,15 @@ def start_runners(
                 workdir = config.workdir / config.tag / runner_.label
                 if runner_.split_by is not None:
                     workdir /= str(group or "unknown")
-
-                result = pool.apply_async(
+                for sample in samples_:
+                    if sample.uuid not in sample_runner_count:
+                        sample_runner_count[sample.uuid] = 1
+                    else:
+                        sample_runner_count[sample.uuid] += 1
+                callback_lock = Lock()
+                callback_lock.acquire()
+                callback_locks.append(callback_lock)
+                pool.apply_async(
                     runner_,
                     kwargs={
                         "config": config,
@@ -256,6 +299,7 @@ def start_runners(
                         "executor_cls": executor_cls,
                         "timestamp": timestamp,
                         "workdir": workdir,
+                        "hooks": hooks,
                         "checkpoints": Checkpoints(
                             samples=samples_,
                             prefix=f"runner.{runner_.name}.{group}" if group else f"runner.{runner_.name}",
@@ -263,8 +307,24 @@ def start_runners(
                             config=config,
                         )
                     },
+                    callback=partial(
+                        runner_callback,
+                        logger=logger,
+                        samples=result_samples,
+                        sample_runner_count=sample_runner_count,
+                        cleaner=cleaner,
+                        pool=pool,
+                        hooks=hooks,
+                        config=config,
+                        root=root,
+                        executor_cls=executor_cls,
+                        timestamp=timestamp,
+                        lock=callback_lock
+                    ),
                 )
-                results.append(result)
+
+            for lock in callback_locks:
+                lock.acquire()
             pool.stop_and_join()
         except KeyboardInterrupt:
             logger.critical("Received SIGINT, telling runners to shut down...")
@@ -274,18 +334,4 @@ def start_runners(
             logger.critical(f"Unhandled exception in runner: {exc!r}")
             pool.terminate()
 
-    try:
-        cleaners: Sequence[DeferredCleaner]
-        samples_, cleaners = zip(*(r.get() for r in results))
-        samples_ = reduce(lambda a, b: a & b, iter(samples_))
-        for cleaner_ in cleaners:
-            cleaner &= cleaner_
-    except Exception as exc:  # pylint: disable=broad-except
-        logger.critical(
-            f"Unhandled exception when collecting results: {exc!r}",
-            exc_info=True,
-        )
-        for sample in samples.unprocessed:
-            sample.fail("Sample was not processed")
-        return samples
-    return samples_
+    return result_samples if len(result_samples) > 0 else samples

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -346,17 +346,19 @@ class Test_Samples:
 
     @staticmethod
     def test_and() -> None:
+        
+
         class _SamplesSubA(data.Samples):
             pass
 
-        _samples_a1 = _SamplesSubA(
+        _samples_a1: data.Samples = data.Samples(
             [
                 data.Sample(id="a1_1", files=["a1_1"]),
                 data.Sample(id="a1_2", files=["a1_2"]),
             ],
         )
 
-        _samples_a2 = _SamplesSubA(
+        _samples_a2: data.Samples = data.Samples(
             [
                 data.Sample(id="a2_1", files=["a2_1"]),
                 data.Sample(id="a2_2", files=["a2_2"]),

--- a/tests/test_integration/test_cleanup.py
+++ b/tests/test_integration/test_cleanup.py
@@ -166,6 +166,6 @@ class Test_cleanup(BaseTest):
     )
     def test_cleanup_deferred_invalid_call(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
-            "Unhandled exception when collecting results: ValueError('Invalid action: DUMMY')"
+            "Exception when merging cleaners: ValueError('Invalid action: DUMMY')"
         )
         assert invocation.exit_code == 0

--- a/tests/test_integration/test_exceptions.py
+++ b/tests/test_integration/test_exceptions.py
@@ -58,9 +58,7 @@ class Test_exceptions(BaseTest):
         },
     )
     def test_merge_exception(self, invocation: Invocation) -> None:
-        assert invocation.logs == literal(
-            "Unhandled exception when collecting results: Exception('DUMMY')"
-        )
+        assert invocation.logs == literal("Exception when merging samples: Exception('DUMMY')")
         assert invocation.exit_code == 0
 
     @mark.override(

--- a/tests/test_integration/test_runner.py
+++ b/tests/test_integration/test_runner.py
@@ -119,7 +119,7 @@ class Test_runners(BaseTest):
     )
     def test_results_exception(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
-            "Unhandled exception when collecting results: Exception('DUMMY')"
+            "Exception when merging samples: Exception('DUMMY')"
         )
 
     @mark.override(

--- a/tests/test_integration/test_samples.py
+++ b/tests/test_integration/test_samples.py
@@ -128,7 +128,7 @@ class Test_samples(BaseTest):
                 def test_hook(samples, logger, **_):
                     for sample in samples:
                         if sample.id == "files":
-                            logger.info(f"Files: {[str(f) for f in sample.files]}")
+                            logger.info(f"Files: {sorted([str(f) for f in sample.files])}")
                         elif sample.id == "meta":
                             logger.info(f"meta.common_key={sorted(sample.meta['common_key'])}")
                             logger.info(f"meta.a={sample.meta['a']}")
@@ -148,11 +148,14 @@ class Test_samples(BaseTest):
     )
     def test_merge(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
-            "Files: ['input.txt', 'extra_a.txt', 'extra_b.txt']",
+            "Files: ['extra_a.txt', 'extra_b.txt', 'input.txt']",
             "meta.common_key=['value_a', 'value_b']",
             "meta.a=unique_for_a",
             "meta.b=unique_for_b",
-            "Failed: Reason A\nReason B",
+        )
+        assert (
+            invocation.logs == literal("Failed: Reason A\nReason B")
+            or invocation.logs == literal("Failed: Reason B\nReason A")
         )
 
 


### PR DESCRIPTION
### The What

Adds support for hooks that run before/after each runner and after and individual sample has been processed by all samples.  

### The Why

Previously, hooks ran before or after ALL runners had finished processing ALL samples. This proved too inflexible, and lead to situations where a particularly slow sample would prevent completed samples from continuing to be processed. It is also desirable for hooks to be able to notify users of failed samples while the wrapper is still processing other samples.

### The How

Adds a `per` option to the `@pre_hook` and `@post_hook` decorators. This option can be set to `"session"` (the default, old behavior), `"sample"` (runs whenever all runners finish processing a sample, only relevant for post-hooks), or `"runner"` (runs before/after each individual runner, inside the runner process).

Under the hood, this fundamentally changes how samples are merged, moving all merging logic into a callback for the runner `mpire.WorkerPool`. Each time a runner returns, its samples are merged into the results `Samples` instance.

All affected tests are passing, so the end result shouldn't be affected, but potential untested inconsistencies with the old behavior is probably still the biggest concern for this change.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
