### PR TITLE
fix: Isolate executor conda environments from global/user configuration 

### DIFF
--- a/src/cellophane/executors/scripts/bootstrap_micromamba.sh
+++ b/src/cellophane/executors/scripts/bootstrap_micromamba.sh
@@ -22,6 +22,28 @@ fi
 
 mkdir -p "${TMPDIR}/mamba"
 $DL "https://micro.mamba.pm/api/micromamba/${PLATFORM}-${ARCH}/latest" | tar -xvjC "${TMPDIR}/mamba" "bin/micromamba"
-eval "$("${TMPDIR}/mamba/bin/micromamba" shell hook -s posix)"
-micromamba env create -p "${TMPDIR}/mamba/${_CONDA_ENV_NAME}" -f "${_CONDA_ENV_SPEC}"
-micromamba run -p "${TMPDIR}/mamba/${_CONDA_ENV_NAME}" "$@"
+
+MAMBA_BIN="${TMPDIR}/mamba/bin/micromamba"
+CONDA_RC="${TMPDIR}/mamba/.condarc"
+eval "$("${MAMBA_BIN}" shell hook -s posix)"
+
+cat <<EOF > "${CONDA_RC}"
+pkgs_dirs:
+  - ${TMPDIR}/mamba/pkgs
+envs_dirs:
+  - ${TMPDIR}/mamba/envs
+EOF
+
+"${MAMBA_BIN}" \
+  --no-env \
+  --rc-file "${CONDA_RC}" \
+  env create \
+  -p "${TMPDIR}/mamba/${_CONDA_ENV_NAME}" \
+  -f "${_CONDA_ENV_SPEC}"
+
+"${MAMBA_BIN}" \
+  --no-rc \
+  --no-env \
+  run \
+  -p "${TMPDIR}/mamba/${_CONDA_ENV_NAME}" \
+  "$@"


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What

Force micromamba to cache packages in a temporary directory and disable reading conda config from file.

### The Why

Fixes a bug where micromamba uses the current user's `conda_pkgs_dirs` which can lead to bad behavior when several processes try to perform transactions at once.

Fixes user dependent bugs when the user has own config(s) for `mamba`/`conda`/`micromamba` that interfere with normal execution.

### The How

Set the `CONDA_PKGS_DIRS` to `$TMPDIR/mamba/pkgs` when creating the environment.

Pass the `--no-rc` flag to `micromamba`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
