### PR TITLE
feat: Custom timestamp class

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -95,7 +95,7 @@ Argument    | Type                    | Description
 ------------|-------------------------|-------------
 `samples`   | `cellophane.Samples`    | Samples to process.
 `config`    | `cellophane.Config`     | Wrapper configuration.
-`timestamp` | `time.struct_time`      | Pipeline starting time.
+`timestamp` | `cellophane.Timestamp`  | Pipeline starting time.
 `logger`    | `logging.LoggerAdapter` | A logger that can be used to log messages.
 `root`      | `pathlib.Path`          | A `pathlib.Path` pointing to the root directory of the wrapper repository.
 `workdir`   | `pathlib.Path`          | A `pathlib.Path` pointing to the working directory of the hook.
@@ -127,7 +127,7 @@ Argument      | Type                     | Description
 --------------|--------------------------|-------------
 `samples`     | `cellophane.Samples`     | Samples to process.
 `config`      | `cellophane.Config`      | Wrapper configuration.
-`timestamp`   | `time.struct_time`       | Pipeline starting time.
+`timestamp`   | `cellophane.Timestamp`   | Pipeline starting time.
 `logger`      | `logging.LoggerAdapter`  | A logger that can be used to log messages.
 `root`        | `pathlib.Path`           | A `pathlib.Path` pointing to the root directory of the wrapper.
 `workdir`     | `pathlib.Path`           | A `pathlib.Path` pointing to the working directory of the runner.
@@ -153,6 +153,7 @@ Argument      | Type              | Description
 `label`       | `str`             | A label for the pre-hook to use in logs. If not specified, the function name will be used. Note that the hook name (used in `before`/`after`) will always be the same as the function name.
 `before`      | `str\|list[str]` | A name or list of names specifying which pre-hooks this pre-hook will run before. If `before` is set to `"all"`, the pre-hook will run before all other pre-hooks.
 `after`       | `str\|list[str]` | A name or list of names specifying which pre-hooks will run before this pre-hook. If `after` is set to `"all"`, the pre-hook will run after all other pre-hooks.
+
 ---
 
 At runtime, the decorated function (hook) will be called with the following keyword arguments:
@@ -161,7 +162,7 @@ Argument    | Type                    | Description
 ------------|-------------------------|-------------
 `samples`   | `cellophane.Samples`    | Samples to process.
 `config`    | `cellophane.Config`     | Wrapper configuration.
-`timestamp` | `time.struct_time`      | Pipeline starting time.
+`timestamp` | `cellophane.Timestamp`  | Pipeline starting time.
 `logger`    | `logging.LoggerAdapter` | A logger that can be used to log messages.
 `root`      | `pathlib.Path`          | A `pathlib.Path` pointing to the root directory of the wrapper repository.
 `workdir`   | `pathlib.Path`          | A `pathlib.Path` pointing to the working directory of the hook.

--- a/src/cellophane/__init__.py
+++ b/src/cellophane/__init__.py
@@ -7,6 +7,7 @@ from .cleanup import Cleaner
 from .data import Container, Output, OutputGlob, Sample, Samples
 from .executors import Executor
 from .modules import Checkpoint, Checkpoints, output, post_hook, pre_hook, runner
+from .util import Timestamp
 
 __all__ = [
     "CELLOPHANE_ROOT",
@@ -39,4 +40,6 @@ __all__ = [
     "Checkpoints",
     # cleanup
     "Cleaner",
+    # util
+    "Timestamp",
 ]

--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -25,6 +25,7 @@ from cellophane.logs import (
     start_logging_queue_listener,
 )
 from cellophane.modules import Hook, Runner, load, run_hooks, start_runners
+from cellophane.util import Timestamp
 
 spec = find_spec("cellophane")
 CELLOPHANE_ROOT = Path(spec.origin).parent  # type: ignore[union-attr, arg-type]
@@ -87,8 +88,8 @@ def cellophane(label: str, root: Path) -> click.Command:
         @with_options(schema)
         def inner(config: Config, **_: Any) -> None:
             """Run cellophane"""
-            start_time = time.localtime()
-            config.tag = config.get("tag", time.strftime("%y%m%d-%H%M%S", start_time))
+            start_time = Timestamp()
+            config.tag = config.get("tag", str(start_time))
             config.logfile = config.logdir / f"{label}.{config.tag}.log"
 
             handle_warnings()
@@ -135,7 +136,7 @@ def cellophane(label: str, root: Path) -> click.Command:
                 log_listener.stop()
                 raise SystemExit(1) from exc
 
-            time_elapsed = format_timespan(time.time() - time.mktime(start_time))
+            time_elapsed = format_timespan(time.time() - start_time)
             logger.info(f"Execution complete in {time_elapsed}")
             log_listener.stop()
 
@@ -155,7 +156,7 @@ def _main(
     config: Config,
     root: Path,
     executor_cls: type[Executor],
-    timestamp: time.struct_time,
+    timestamp: Timestamp,
 ) -> None:
     """Run cellophane"""
     # Load samples from file, or create empty samples object

--- a/src/cellophane/data/output.py
+++ b/src/cellophane/data/output.py
@@ -9,6 +9,8 @@ from warnings import warn
 from attrs import define, field
 from attrs.setters import convert
 
+from cellophane.util import Timestamp
+
 from .container import Container
 
 
@@ -87,7 +89,7 @@ class OutputGlob:  # type: ignore[no-untyped-def]
         samples: Iterable,
         workdir: Path,
         config: Container,
-        timestamp: time.struct_time,
+        timestamp: Timestamp,
     ) -> set[Output]:
         """Resolve the glob pattern to a list of files to be copied.
 
@@ -112,6 +114,7 @@ class OutputGlob:  # type: ignore[no-untyped-def]
                 "config": config,
                 "workdir": workdir,
                 "sample": sample,
+                "timestamp": timestamp,
             }
 
             match self.src.format(**meta):
@@ -126,27 +129,24 @@ class OutputGlob:  # type: ignore[no-untyped-def]
                 warn(f"No files matched pattern '{pattern}'")
 
             for m in matches:
-                if self.dst_dir is None:
-                    dst_dir = config.resultdir
-                else:
-                    _dst_dir = self.dst_dir.format(**meta)
-                    _dst_dir = time.strftime(_dst_dir, timestamp)
+                match self.dst_dir:
+                    case str(d) if Path(d).is_absolute():
+                        dst_dir = Path(d.format(**meta))
+                    case str(d):
+                        dst_dir = config.resultdir / d.format(**meta)
+                    case _:
+                        dst_dir = config.resultdir
 
-                    if Path(_dst_dir).is_absolute():
-                        dst_dir = Path(_dst_dir)
-                    else:
-                        dst_dir = config.resultdir / _dst_dir
-
-                if self.dst_name is None:
-                    dst_name = m.name
-                elif len(matches) > 1:
-                    warn(
-                        f"Destination name {self.dst_name} will be ignored as '{self.src}' matches multiple files"
-                    )
-                    dst_name = m.name
-                else:
-                    dst_name = self.dst_name.format(**meta)
-                    dst_name = time.strftime(dst_name, timestamp)
+                match self.dst_name:
+                    case None:
+                        dst_name = m.name
+                    case _ if len(matches) > 1:
+                        warn(
+                            f"Destination name {self.dst_name} will be ignored as '{self.src}' matches multiple files"
+                        )
+                        dst_name = m.name
+                    case str() as n:
+                        dst_name = n.format(**meta)
 
                 dst = Path(dst_dir) / dst_name
 

--- a/src/cellophane/modules/checkpoint.py
+++ b/src/cellophane/modules/checkpoint.py
@@ -11,6 +11,7 @@ from xxhash import xxh3_64
 
 from cellophane.cfg import Config
 from cellophane.data import Output, OutputGlob, Samples
+from cellophane.util import Timestamp
 
 
 @define
@@ -59,7 +60,7 @@ class Checkpoint:
                     workdir=self.workdir,
                     # Only src is considered, so using the current time works
                     # since timestamps are never included in src paths
-                    timestamp=time.localtime(),
+                    timestamp=Timestamp(),
                 )
                 output_paths = {o.src for o in outputs}
 

--- a/src/cellophane/modules/hook.py
+++ b/src/cellophane/modules/hook.py
@@ -11,6 +11,7 @@ from cellophane.cfg import Config
 from cellophane.cleanup import Cleaner
 from cellophane.data import Samples
 from cellophane.executors import Executor
+from cellophane.util import Timestamp
 
 
 class _AFTER_ALL: ...
@@ -88,7 +89,7 @@ class Hook:
         root: Path,
         executor_cls: type[Executor],
         log_queue: Queue,
-        timestamp: time.struct_time,
+        timestamp: Timestamp,
         cleaner: Cleaner,
     ) -> Samples:
         logger = LoggerAdapter(getLogger(), {"label": self.label})
@@ -162,7 +163,7 @@ def run_hooks(
     root: Path,
     executor_cls: type[Executor],
     log_queue: Queue,
-    timestamp: time.struct_time,
+    timestamp: Timestamp,
     cleaner: Cleaner,
     logger: LoggerAdapter,
 ) -> Samples:

--- a/src/cellophane/modules/runner_.py
+++ b/src/cellophane/modules/runner_.py
@@ -16,6 +16,7 @@ from cellophane.cleanup import Cleaner, DeferredCleaner
 from cellophane.data import OutputGlob, Samples
 from cellophane.executors import Executor
 from cellophane.logs import handle_warnings, redirect_logging_to_queue
+from cellophane.util import Timestamp
 
 from .checkpoint import Checkpoints
 
@@ -60,7 +61,7 @@ class Runner:
         root: Path,
         samples: Samples,
         executor_cls: type[Executor],
-        timestamp: time.struct_time,
+        timestamp: Timestamp,
         workdir: Path,
     ) -> tuple[Samples, DeferredCleaner]:
         handle_warnings()
@@ -148,7 +149,7 @@ def _resolve_outputs(
     samples: Samples,
     workdir: Path,
     config: Config,
-    timestamp: time.struct_time,
+    timestamp: Timestamp,
     logger: LoggerAdapter,
 ) -> None:
     for output_ in samples.output.copy():
@@ -201,7 +202,7 @@ def start_runners(
     config: Config,
     root: Path,
     executor_cls: type[Executor],
-    timestamp: time.struct_time,
+    timestamp: Timestamp,
     cleaner: Cleaner,
 ) -> Samples:
     """Start cellphane runners in parallel and collect the results.

--- a/src/cellophane/util/__init__.py
+++ b/src/cellophane/util/__init__.py
@@ -3,6 +3,7 @@
 from .freeze import freeze, frozenlist, unfreeze
 from .mappings import map_nested_keys, merge_mappings
 from .misc import freeze_logs, is_instance_or_subclass
+from .timestamp import Timestamp
 
 __all__ = [
     "freeze",
@@ -12,4 +13,5 @@ __all__ = [
     "merge_mappings",
     "is_instance_or_subclass",
     "freeze_logs",
+    "Timestamp",
 ]

--- a/src/cellophane/util/timestamp.py
+++ b/src/cellophane/util/timestamp.py
@@ -1,0 +1,41 @@
+from time import gmtime, localtime, strftime, struct_time, time
+
+from attrs import define, field
+
+
+@define(frozen=True)
+class Timestamp:
+    time: float = field(factory=time)
+
+    @property
+    def gmtime(self) -> struct_time:
+        return gmtime(self.time)
+
+    @property
+    def localtime(self) -> struct_time:
+        return localtime(self.time)
+
+
+    def __getitem__(self, key: str) -> str:
+        return strftime(key, self.localtime)
+
+    def __str__(self) -> str:
+        return self['%y%m%d-%H%M%S']
+
+    def __float__(self) -> float:
+        return self.time
+
+    def __int__(self) -> int:
+        return int(self.time)
+
+    def __sub__(self, other: int | float) -> float:
+        if not isinstance(other, (int, float)):
+            raise NotImplementedError
+
+        return self.time - other
+
+    def __rsub__(self, other: int | float) -> float:
+        if not isinstance(other, (int, float)):
+            raise NotImplementedError
+
+        return other - self.time

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -7,8 +7,9 @@ from typing import ClassVar
 
 import dill
 from attrs import define, field
-from cellophane import data
-from pytest import fixture, mark, param, raises
+from cellophane import Timestamp, data
+from pytest import FixtureRequest, MonkeyPatch, fixture, mark, param, raises
+from pytest_mock import MockerFixture
 
 LIB = Path(__file__).parent / "lib"
 

--- a/tests/test_integration/test_outputs.py
+++ b/tests/test_integration/test_outputs.py
@@ -1,3 +1,5 @@
+from time import gmtime
+
 from cellophane.testing import BaseTest, Invocation, literal, regex
 
 
@@ -40,6 +42,10 @@ class Test_outputs(BaseTest):
             @output("missing.txt")
             @output("glob/*.txt", dst_name="invalid_rename.txt")
             @output("single.txt", dst_name="rename.txt")
+            @output("glob/*.txt", dst_dir="timestamp_fmt_dir_{timestamp[%H%M%S]}")
+            @output("single.txt", dst_name="timestamp_fmt_name_{timestamp[%H%M%S]}.txt")
+            @output("glob/*.txt", dst_dir="timestamp_dir_{timestamp}")
+            @output("single.txt", dst_name="timestamp_name_{timestamp}.txt")
             @output("overwrite_a.txt", dst_name="overwrite.txt")
             @output("overwrite_b.txt", dst_name="overwrite.txt")
             @output("nested/**/*.txt")
@@ -82,10 +88,11 @@ class Test_outputs(BaseTest):
         "input/a.txt": "INPUT_A",
         "input/b.txt": "INPUT_B",
     }
+    mocks = {"cellophane.util.timestamp.localtime": {"new": lambda *_: gmtime(1092587022.0)}}
 
     def test_outputs(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
-            "Copying 17 outputs",
+            "Copying 23 outputs",
             "Copying out/DUMMY/runner_a/single.txt to out/results/single.txt",
             "Copying out/DUMMY/runner_a/sample_a.txt to out/results/sample_a.txt",
             "Copying out/DUMMY/runner_a/sample_b.txt to out/results/sample_b.txt",
@@ -93,6 +100,12 @@ class Test_outputs(BaseTest):
             "Copying out/DUMMY/runner_a/glob/a.txt to out/results/a.txt",
             "Copying out/DUMMY/runner_a/glob/b.txt to out/results/b.txt",
             "Copying out/DUMMY/runner_a/single.txt to out/results/rename.txt",
+            "Copying out/DUMMY/runner_a/glob/a.txt to out/results/timestamp_dir_040815-162342/a.txt",
+            "Copying out/DUMMY/runner_a/glob/b.txt to out/results/timestamp_dir_040815-162342/b.txt",
+            "Copying out/DUMMY/runner_a/glob/a.txt to out/results/timestamp_fmt_dir_162342/a.txt",
+            "Copying out/DUMMY/runner_a/glob/b.txt to out/results/timestamp_fmt_dir_162342/b.txt",
+            "Copying out/DUMMY/runner_a/single.txt to out/results/timestamp_name_040815-162342.txt",
+            "Copying out/DUMMY/runner_a/single.txt to out/results/timestamp_fmt_name_162342.txt",
             "to out/results/overwrite.txt",
             "out/results/overwrite.txt already exists",
             "Copying out/DUMMY/runner_a/nested/a/x.txt to out/results/x.txt",


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What

Add a custom class for timestamps.

### The Why

Previously, to allow using the timestamp in outputs, `dst_path`/`dst_name` patterns were simply passed through `strftime` using a `struct_time` for the timestamp. While this is a simple solution, it makes the output naming less obvious as it doesn't follow the format-string style. Furthermore, the current solution is technically not backwards compatible, as names including '%' now require escaping.

### The How

Adds a custom `Timestamp` class. String interpolation of a `Timestamp` object produces a timestamp formatted as`%y%m%d-%H%M%S`. Any other format timestamp can be produced by subseting, eg.`timestamp["%a, %d %b %Y %H:%M:%S"]`, using normal `strftime` syntax. 

Additionally, a Timestamp can be interpreted as a float or int (seconds since epoch), or directly subtracted from a float/int (eg. `time.time` to give seconds since wrapper start).

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
