### PR TITLE
feat: Async module loading

### DIFF
--- a/src/cellophane/data/samples.py
+++ b/src/cellophane/data/samples.py
@@ -57,6 +57,8 @@ def _apply_mixins(
         name_ += f"_{mixin.__name__}"
         if "__attrs_attrs__" not in mixin.__dict__:
             mixin = define(mixin, slots=False)
+        if cls not in mixin.__bases__:
+            mixin.__bases__ = (cls,)
 
         mixins_.append(mixin)
 

--- a/src/cellophane/modules/load.py
+++ b/src/cellophane/modules/load.py
@@ -1,6 +1,8 @@
 """Module loader for cellophane modules."""
 
-from importlib import import_module
+import asyncio as aio
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from site import addsitedir
 
@@ -11,16 +13,67 @@ from cellophane.util import freeze_logs, is_instance_or_subclass
 from .hook import Hook, resolve_dependencies
 from .runner_ import Runner
 
-
-def load(
-    root: Path,
-) -> tuple[
+MODULE_CONTENTS = tuple[
     list[Hook],
     list[Runner],
     list[type[Sample]],
     list[type[Samples]],
     list[type[Executor]],
-]:
+]
+
+
+async def _async_load(file: Path) -> MODULE_CONTENTS:
+    hooks: list[Hook] = []
+    runners: list[Runner] = []
+    sample_mixins: list[type[Sample]] = []
+    samples_mixins: list[type[Samples]] = []
+    executors_: list[type[Executor]] = []
+
+    try:
+        if (
+            (base := (file.stem if file.stem != "__init__" else file.parent.name))
+            and (spec := spec_from_file_location(f"modules.{base}", file)) is not None
+            and (module := module_from_spec(spec)) is not None
+            and (loader := spec.loader) is not None
+        ):
+            sys.modules[f"modules.{base}"] = module
+            loader.exec_module(module)
+    except Exception as exc:
+        raise ImportError(f"Unable to import module '{base}': {exc!r}") from exc
+
+    for obj in [getattr(module, a) for a in dir(module)]:
+        if is_instance_or_subclass(obj, Hook):
+            hooks.append(obj)
+        elif is_instance_or_subclass(obj, Sample):
+            sample_mixins.append(obj)
+        elif is_instance_or_subclass(obj, Samples):
+            samples_mixins.append(obj)
+        elif is_instance_or_subclass(obj, Runner):
+            runners.append(obj)
+        elif is_instance_or_subclass(obj, Executor):
+            executors_.append(obj)
+
+    return hooks, runners, sample_mixins, samples_mixins, executors_
+
+
+async def _gather_module_contents(root: Path) -> MODULE_CONTENTS:
+    futures = [
+        aio.create_task(_async_load(file))
+        for file in [
+            *(root / "modules").glob("*.py"),
+            *(root / "modules").glob("*/__init__.py"),
+        ]
+        if file != (root / "modules" / "__init__.py")
+    ]
+    results: MODULE_CONTENTS = ([], [], [], [], [SubprocessExecutor, MockExecutor])
+    for future in aio.as_completed(futures):
+        result = await future
+        for i, r in enumerate(result):
+            results[i].extend(r)  # type: ignore[arg-type]
+    return results
+
+
+def load(root: Path) -> MODULE_CONTENTS:
     """Loads module(s) from the specified path and returns the hooks, runners,
     sample mixins, and samples mixins found within.
 
@@ -39,48 +92,18 @@ def load(
             and samples mixins.
 
     """
-    hooks: list[Hook] = []
-    runners: list[Runner] = []
-    sample_mixins: list[type[Sample]] = []
-    samples_mixins: list[type[Samples]] = []
-    executors_: list[type[Executor]] = [SubprocessExecutor, MockExecutor]
-    error = None
-
     addsitedir(str(root))
     with freeze_logs():
-        for file in [
-            *(root / "modules").glob("*.py"),
-            *(root / "modules").glob("*/__init__.py"),
-        ]:
-            if (
-                base := file.stem if file.stem != "__init__" else file.parent.name
-            ) == "modules":
-                continue
-
-            try:
-                module = import_module(f".{base}", "modules")
-            except Exception as exc:
-                error = f"Unable to import module '{base}': {exc!r}"
-                break
-
-            for obj in [getattr(module, a) for a in dir(module)]:
-                if is_instance_or_subclass(obj, Hook):
-                    hooks.append(obj)
-                elif is_instance_or_subclass(obj, Sample):
-                    sample_mixins.append(obj)
-                elif is_instance_or_subclass(obj, Samples):
-                    samples_mixins.append(obj)
-                elif is_instance_or_subclass(obj, Runner):
-                    runners.append(obj)
-                elif is_instance_or_subclass(obj, Executor):
-                    executors_.append(obj)
-
+        (
+            hooks,
+            runners,
+            sample_mixins,
+            samples_mixins,
+            executors_,
+        ) = aio.run(_gather_module_contents(root))
     try:
         hooks = resolve_dependencies(hooks)
     except Exception as exc:  # pylint: disable=broad-except
-        error = f"Unable to resolve hook dependencies: {exc!r}"
-
-    if error is not None:
-        raise ImportError(error)
+        raise ImportError(f"Unable to resolve hook dependencies: {exc!r}") from exc
 
     return hooks, runners, sample_mixins, samples_mixins, executors_


### PR DESCRIPTION
## Contents

### The What

Make module loading asynchronous.

### The Why

Profiling of real-world wrappers has shown that cellophane spends a lot of time inside `importlib` machinery. It is difficult to reproduce this in a minimal test-case, but the hope is that doing this async will improve performance.

### The How

Split the previous `load` function into asynchronous functions, `_async_load` and `_gather_module_contents`. These are then called from the new `load` function with the individual module paths.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
