### PR TITLE
feat!: Use JSON for array and mapping types on the CLI

### DIFF
--- a/src/cellophane/cfg/flag.py
+++ b/src/cellophane/cfg/flag.py
@@ -8,7 +8,6 @@ from attrs import define, field, setters
 
 from .click_ import (
     FORMATS,
-    ITEMS_TYPES,
     SCHEMA_TYPES,
     FormattedString,
     InvertibleParamType,
@@ -35,7 +34,7 @@ class Flag:
     ----------
         key (list[str] | None): The key associated with the flag.
         type SCHEMA_TYPES: The JSONSchema type of the flag.
-        items ITEMS_TYPES: The JSONSchema items type of the flag.
+        items SCHEMA_TYPES: The JSONSchema items type of the flag.
         format_ FORMATS: The JSONSchema format of the flag.
         minimum (int | None): The minimum value of the flag.
         maximum (int | None): The maximum value of the flag.
@@ -56,18 +55,7 @@ class Flag:
 
     key: tuple[str, ...] = field(converter=_convert_tuple, on_setattr=setters.convert)
     type: SCHEMA_TYPES | None = field(default=None)
-    items_type: ITEMS_TYPES | None = field(default=None)
-    items_format: FORMATS | None = field(default=None)
-    items_min: int | None = field(
-        default=None,
-        converter=_convert_float,
-        on_setattr=setters.convert,
-    )
-    items_max: int | None = field(
-        default=None,
-        converter=_convert_float,
-        on_setattr=setters.convert,
-    )
+    items: dict | None = field(default=None)
     min: int | None = field(
         default=None,
         converter=_convert_float,
@@ -149,10 +137,7 @@ class Flag:
             min_=self.min,
             max_=self.max,
             enum=self.enum,
-            items_type=self.items_type,
-            items_format=self.items_format,
-            items_min=self.items_min,
-            items_max=self.items_max,
+            items=self.items,
         )
 
     @property
@@ -201,7 +186,6 @@ class Flag:
                 else f"--{self.flag}"
             ),
             type=self.click_type,
-            multiple=self.items_type == "array",
             default=(
                 True
                 if self.type == "boolean" and self.default is None

--- a/src/cellophane/cfg/jsonschema_.py
+++ b/src/cellophane/cfg/jsonschema_.py
@@ -121,10 +121,7 @@ def properties_(
                 "enum": subschema.get("enum"),
                 "description": subschema.get("description"),
                 "secret": subschema.get("secret", False),
-                "items_type": subschema.get("items", {}).get("type"),
-                "items_format": subschema.get("items", {}).get("format"),
-                "items_min": subschema.get("items", {}).get("minimum"),
-                "items_max": subschema.get("items", {}).get("maximum"),
+                "items": subschema.get("items"),
                 "format": subschema.get("format"),
                 "pattern": subschema.get("pattern"),
                 "min": subschema.get("minimum"),
@@ -157,12 +154,7 @@ def required_(
     if instance is not None:
         for prop in required:
             subschema = schema.get("properties", {}).get(prop)
-            if not (
-                subschema is None
-                or "default" in subschema
-                or "properties" in subschema
-                or prop in instance
-            ):
+            if not (subschema is None or "default" in subschema or "properties" in subschema or prop in instance):
                 key = (*(_path or ()), prop)
                 flags[key] = flags.get(key, Flag(key=key))
                 flags[key].required = True

--- a/tests/lib/integration/cfg.yaml
+++ b/tests/lib/integration/cfg.yaml
@@ -84,7 +84,7 @@
     --a: "INVALID"
     --workdir: out
   exception: |-
-    BadParameter('Expected a comma separated mapping (a=b,x=y), got INVALID')
+    BadParameter("Expected a valid JSON mapping, got 'INVALID'")
 
 - id: bad_item_type
   structure:
@@ -95,10 +95,10 @@
           items:
             type: number
   args:
-    --a: !!python/tuple ["INVALID"]
+    --a: '["INVALID"]'
     --workdir: out
   exception: |-
-    BadParameter("could not convert string to float: 'INVALID'")
+    BadParameter("Unable to convert value: could not convert string to float: 'INVALID'")
 
 - id: invalid_item_type
   structure:
@@ -146,7 +146,7 @@
     --a: "INVALID"
     --workdir: out
   exception: |-
-    BadParameter("'INVALID' does not match pattern: '^[a-z]+$'")
+    BadParameter("'INVALID' does not match pattern '^[a-z]+$'")
 
 - &parse_config
   id: parse_config
@@ -197,7 +197,7 @@
         typed_array:
           type: array
           items:
-            type: integer
+            type: string
         array:
           type: array
         mapping:
@@ -216,8 +216,8 @@
       boolean:
         a: true
         b: false
-      typed_array: [1, 3, 3, 7]
-      array: [1, 3, 3, 7]
+      typed_array: ["1", 3.0, "3.0", 7]
+      array: ["1", 3.0, "3.0", 7]
       mapping:
         a: "a"
         b: 1
@@ -239,15 +239,15 @@
   - key='boolean' k='a' v=True (bool)
   - key='boolean' k='b' v=False (bool)
   - key='typed_array' (list)
-  - key='typed_array' i=0 v=1 (int)
-  - key='typed_array' i=1 v=3 (int)
-  - key='typed_array' i=2 v=3 (int)
-  - key='typed_array' i=3 v=7 (int)
+  - key='typed_array' i=0 v='1' (str)
+  - key='typed_array' i=1 v='3.0' (str)
+  - key='typed_array' i=2 v='3.0' (str)
+  - key='typed_array' i=3 v='7' (str)
   - key='array' (list)
   - key='array' i=0 v='1' (str)
-  - key='array' i=1 v='3' (str)
-  - key='array' i=2 v='3' (str)
-  - key='array' i=3 v='7' (str)
+  - key='array' i=1 v=3.0 (float)
+  - key='array' i=2 v='3.0' (str)
+  - key='array' i=3 v=7 (int)
   - key='mapping' (PreservedDict)
   - key='mapping' k='a' v='a' (str)
   - key='mapping' k='b' v=1 (int)
@@ -267,8 +267,8 @@
     --integer: "1"
     --boolean_a: ~
     --boolean_no_b: ~
-    --typed_array: !!python/tuple [1, 3, 3, 7]
-    --array: !!python/tuple [1, 3, 3, 7]
-    --mapping: a="a",b=1,c=1.0,d.e="e",d.f=42
+    --typed_array: '["1", 3.0, "3.0", 7]'
+    --array: '["1", 3.0, "3.0", 7]'
+    --mapping: '{"a":"a","b":1,"c":1.0,"d":{"e":"e","f":42}}'
     --path: "path/to/file"
     --size: "1 GB"

--- a/tests/lib/schema/config/from_cli.yaml
+++ b/tests/lib/schema/config/from_cli.yaml
@@ -41,10 +41,10 @@ cli: [
   "--integer", "1337",
   "--number", "13.37",
   "--boolean",
-  "--array", ["one", "two", "three"],
-  "--typed_array", ["1.0", "2.0", "3.0"],
-  "--mapping_array", ["a=X", "b=Y"],
-  "--mapping", "a=X,b=Y",
+  "--array", '["one", "two", "three"]',
+  "--typed_array", '["1.0", "2.0", "3.0"]',
+  "--mapping_array", '[{"a": "X"}, {"b": "Y"}]',
+  "--mapping", '{"a":"X","b":"Y"}',
   "--nested_a_b_c", "Z"
 ]
 

--- a/tests/lib/schema/flags/typed_array.yaml
+++ b/tests/lib/schema/flags/typed_array.yaml
@@ -14,4 +14,5 @@ flags:
   - key: !!python/tuple [a]
     type: array
     value: [a, b, c]
-    items_type: path
+    items:
+      type: path

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -31,27 +31,17 @@ class Test_StringMapping:
         "value,expected",
         [
             param(
-                "a=b,c=d",
+                '{"a": "b", "c": "d"}',
                 {"a": "b", "c": "d"},
                 id="simple",
             ),
             param(
-                'a="a",c="d"',
-                {"a": "a", "c": "d"},
-                id="quoted",
-            ),
-            param(
-                "a='a',c='d'",
-                {"a": "a", "c": "d"},
-                id="single quoted",
-            ),
-            param(
-                "a.b.c=d",
+                '{"a": {"b": {"c": "d"}}}',
                 {"a": {"b": {"c": "d"}}},
                 id="nested",
             ),
             param(
-                "",
+                "{}",
                 {},
                 id="empty",
             ),
@@ -71,19 +61,11 @@ class Test_StringMapping:
                 id="invalid string",
             ),
             param(
-                "a=b,c=,d=e",
-                id="missing value",
-            ),
-            param(
-                "a=b,=d,d=e",
+                '{:"b"}',
                 id="missing key",
             ),
             param(
-                "a=b,c=d,e",
-                id="missing separator",
-            ),
-            param(
-                "a=b,!c=d",
+                '{!a: "b"}',
                 id="invalid key",
             ),
         ],
@@ -116,7 +98,7 @@ class Test_TypedArray:
         expected: list[int],
     ) -> None:
         """Test TypedArray.convert."""
-        _array = cfg.click_.TypedArray(item_type)
+        _array = cfg.click_.TypedArray({"type": item_type})
         assert _array.convert(value, None, None) == expected  # type: ignore[arg-type]
 
     @staticmethod
@@ -144,7 +126,7 @@ class Test_TypedArray:
     ) -> None:
         """Test TypedArray.convert exceptions."""
         with raises(exception):
-            _array = cfg.click_.TypedArray(item_type)  # type: ignore[arg-type]
+            _array = cfg.click_.TypedArray({"type": item_type})  # type: ignore[arg-type]
             _array.convert(value, None, None)  # type: ignore[arg-type]
 
 
@@ -301,7 +283,7 @@ class Test_Flag:
                     ("integer", click.IntRange(min=0), {"min": 0}),
                     ("number", float, {}),
                     ("number", click.FloatRange(min=0), {"min": 0}),
-                    ("array", TypedArray("string"), {}),
+                    ("array", TypedArray({"type": "string"}), {}),
                     ("mapping", StringMapping(), {}),
                     ("path", click.Path(), {}),
                     ("size", ParsedSize(), {}),


### PR DESCRIPTION
## Contents

### The What

Replace custom array and mapping string syntax with JSON. This is a BREAKING change, as it changes the CLI syntax.

### The Why

Simplifies the implementation, and the syntax is more familiar (albeit more verbose) for users.

### The How

Replace the custom parsers with `json.loads`.

### This [update](https://semver.org/) is:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
