### PR TITLE
Feat executor env

### DIFF
--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -134,7 +134,7 @@ class Executor:
         stdout_path = workdir_ / f"{name}.{uuid.hex}.{self.name}.stdout"
         stderr_path = workdir_ / f"{name}.{uuid.hex}.{self.name}.stderr"
 
-        env_ = env or {}
+        env_ = config.executor.env | env or {}
         args_ = tuple(word for arg in args for word in shlex.split(str(arg)))
         if conda_spec:
             yaml = YAML(typ="safe")

--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -134,7 +134,11 @@ class Executor:
         stdout_path = workdir_ / f"{name}.{uuid.hex}.{self.name}.stdout"
         stderr_path = workdir_ / f"{name}.{uuid.hex}.{self.name}.stderr"
 
-        env_ = config.executor.env | env or {}
+        env_ = config.executor.env | (env or {})
+        path_ = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+        env_["PATH"] = f"{env_['PATH']}:{path_}" if "PATH" in env_ else path_
+        os_env_ = os_env if os_env is not None else config.executor.os_env
+
         args_ = tuple(word for arg in args for word in shlex.split(str(arg)))
         if conda_spec:
             yaml = YAML(typ="safe")
@@ -158,7 +162,7 @@ class Executor:
                 "uuid": uuid,
                 "workdir": workdir_,
                 "env": {k: str(v) for k, v in env_.items()},
-                "os_env": os_env,
+                "os_env": os_env_,
                 "cpus": cpus or config.executor.cpus,
                 "memory": memory or config.executor.memory,
                 "config": config,
@@ -247,7 +251,7 @@ class Executor:
         uuid: UUID | None = None,
         workdir: Path | None = None,
         env: dict | None = None,
-        os_env: bool = True,
+        os_env: bool | None  = None,
         callback: Callable | None = None,
         error_callback: Callable | None = None,
         cpus: int | None = None,

--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -154,7 +154,7 @@ class Executor:
         stdout_path = _workdir / f"{name}.{uuid.hex}.{self.name}.stdout"
         stderr_path = _workdir / f"{name}.{uuid.hex}.{self.name}.stderr"
 
-        _env = env or {}
+        _env = config.executor.env | env or {}
         _args = tuple(word for arg in args for word in shlex.split(str(arg)))
         if conda_spec:
             env_path = build_environment(

--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -154,7 +154,11 @@ class Executor:
         stdout_path = _workdir / f"{name}.{uuid.hex}.{self.name}.stdout"
         stderr_path = _workdir / f"{name}.{uuid.hex}.{self.name}.stderr"
 
-        _env = config.executor.env | env or {}
+        _env = config.executor.env | (env or {})
+        _path = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+        _env["PATH"] = f"{_env['PATH']}:{_path}" if "PATH" in _env else _path
+        _os_env = os_env if os_env is not None else config.executor.os_env
+
         _args = tuple(word for arg in args for word in shlex.split(str(arg)))
         if conda_spec:
             env_path = build_environment(
@@ -193,7 +197,7 @@ class Executor:
                 "uuid": uuid,
                 "workdir": _workdir,
                 "env": {k: str(v) for k, v in _env.items()},
-                "os_env": os_env,
+                "os_env": _os_env,
                 "cpus": cpus or config.executor.cpus,
                 "memory": memory or config.executor.memory,
                 "config": config,
@@ -282,7 +286,7 @@ class Executor:
         uuid: UUID | None = None,
         workdir: Path | None = None,
         env: dict | None = None,
-        os_env: bool = True,
+        os_env: bool | None  = None,
         callback: Callable | None = None,
         error_callback: Callable | None = None,
         cpus: int | None = None,

--- a/src/cellophane/schema.base.yaml
+++ b/src/cellophane/schema.base.yaml
@@ -43,6 +43,10 @@ properties:
         type: size
         description: Ammount of memory to allocate to jobs started (if supported by the executor)
         default: 2 GB
+      os_env:
+        type: boolean
+        description: Inherit environment variables from the parent process (Can be overridden in calls to executor.submit)
+        default: false
       env:
         type: mapping
         description: Environment variables to set for all jobs submitted to the executor

--- a/src/cellophane/schema.base.yaml
+++ b/src/cellophane/schema.base.yaml
@@ -43,6 +43,10 @@ properties:
         type: size
         description: Ammount of memory to allocate to jobs started (if supported by the executor)
         default: 2 GB
+      env:
+        type: mapping
+        description: Environment variables to set for all jobs submitted to the executor
+        default: {}
 
   config_file:
     description: Path to config file

--- a/src/cellophane/schema.base.yaml
+++ b/src/cellophane/schema.base.yaml
@@ -43,6 +43,10 @@ properties:
         type: size
         description: Ammount of memory to allocate to jobs started (if supported by the executor)
         default: 2 GB
+      env_vars:
+        type: mapping
+        description: Environment variables to set for all jobs submitted to the executor
+        default: {}
       environment:
         type: object
         properties:
@@ -79,6 +83,7 @@ properties:
               - emscripten-wasm32
               - wasi-wasm32
               - zos-z
+
 
   config_file:
     description: Path to config file

--- a/src/cellophane/schema.base.yaml
+++ b/src/cellophane/schema.base.yaml
@@ -43,6 +43,10 @@ properties:
         type: size
         description: Ammount of memory to allocate to jobs started (if supported by the executor)
         default: 2 GB
+      os_env:
+        type: boolean
+        description: Inherit environment variables from the parent process (Can be overridden in calls to executor.submit)
+        default: false
       env_vars:
         type: mapping
         description: Environment variables to set for all jobs submitted to the executor

--- a/tests/test_integration/test_executor.py
+++ b/tests/test_integration/test_executor.py
@@ -53,7 +53,7 @@ class Test_executor_submit(BaseTest):
             "MockExecutor called with name='RUNNER'",
             "MockExecutor called with name='HOOK'",
             "cmdline=ping localhost -c 1",
-            "os_env=True",
+            "os_env=False",
             "cpus=1",
             "memory=2000000000",
         )

--- a/tests/test_integration/test_executor.py
+++ b/tests/test_integration/test_executor.py
@@ -55,7 +55,7 @@ class Test_executor_submit(BaseTest):
             "MockExecutor called with name='RUNNER'",
             "MockExecutor called with name='HOOK'",
             "cmdline=ping localhost -c 1",
-            "os_env=True",
+            "os_env=False",
             "cpus=1",
             "memory=2000000000",
         )


### PR DESCRIPTION
## Contents

### The What

Improve executor environment handling.

> [!CAUTION]
> This is a breaking change as wrappers may expect OS env to be used by executor calls


### The Why

Currently, executors inherit the OS env by default, and there is no way to manually set environment variables for all executor submit calls. This is inflexible and leads to undesired and hard to diagnose side effects when users have certain environment variables set.

### The How

- Set `os_env` default to `False` in `executor.submit`
- Expose a configuration parameter for global executor environment variables

### This [update](https://semver.org/) is:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
