### PR TITLE
fix: Ensure Executor subclasses are dill serializable

### DIFF
--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -41,10 +41,18 @@ class Executor:
     config: cfg.Config
     uuid: UUID = field(init=False)
 
-    def __init_subclass__(cls, *args: Any, name: str, **kwargs: Any) -> None:
+    def __init_subclass__(
+        cls,
+        *args: Any,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Register the class in the registry."""
         super().__init_subclass__(*args, **kwargs)
-        cls.name = name or cls.__name__.lower()
+        if name is not None:
+            cls.name = name
+        elif not hasattr(cls, "name"):
+            cls.name = cls.__name__.lower()
 
     def __init__(self, *args: Any, log_queue: mp.Queue, **kwargs: Any) -> None:
         """Initialize the executor."""


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fix a deadlock that sometimes occurs when executor instances are serialized by dill.


### The Why
Tests defining a custom executor class would sometimes deadlock on `executor.submit` because dill would fail to serialize the executor (passed to `_target` as `self` when the job is spawned in the `WorkerPool`).

This was traced back to dill invoking `__init_subclass__` without passing the required `name` parameter.

### The How
Makes the `name` argument for `Executor.__init_subclass__` optional and only use it if passed. Otherwise, re-use `cls.name` if it is present (i.e. when unpickling) or fall back to `cls.__name__.lower()`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
