### PR TITLE
refactor: Overhaul configuration generation

### DIFF
--- a/src/cellophane/__init__.py
+++ b/src/cellophane/__init__.py
@@ -1,10 +1,10 @@
 """Cellophane: A library for writing modular wrappers"""
 
-from .cellophane import CELLOPHANE_ROOT, CELLOPHANE_VERSION, cellophane
 from . import cfg, data, executors, logs, modules, util
+from .cellophane import CELLOPHANE_ROOT, CELLOPHANE_VERSION, cellophane
 from .cfg import Config, Schema
 from .cleanup import Cleaner
-from .data import Output, OutputGlob, Sample, Samples
+from .data import Container, Output, OutputGlob, Sample, Samples
 from .executors import Executor
 from .modules import Checkpoint, Checkpoints, output, post_hook, pre_hook, runner
 
@@ -28,6 +28,7 @@ __all__ = [
     "OutputGlob",
     "Sample",
     "Samples",
+    "Container",
     # executors
     "Executor",
     # cfg

--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -88,7 +88,7 @@ def cellophane(label: str, root: Path) -> click.Command:
         def inner(config: Config, **_: Any) -> None:
             """Run cellophane"""
             start_time = time.localtime()
-            config.tag = config.tag or time.strftime("%y%m%d-%H%M%S", start_time)
+            config.tag = config.get("tag", time.strftime("%y%m%d-%H%M%S", start_time))
 
             handle_warnings()
             console_handler.setLevel(config.log.level)

--- a/src/cellophane/cfg/config.py
+++ b/src/cellophane/cfg/config.py
@@ -6,7 +6,6 @@ from attrs import define, field
 
 from cellophane import data
 
-from .jsonschema_ import get_flags
 from .schema import Schema
 
 
@@ -16,13 +15,12 @@ class Config(data.Container):
 
     Attributes:
     ----------
-        schema (Schema): The schema associated with the configuration.
+        __schema__ (Schema): The schema associated with the configuration.
 
     Methods:
     -------
         __init__(
             schema: Schema,
-            allow_empty: bool = False,
             _data: dict | None = None,
             **kwargs,
         ):
@@ -31,9 +29,7 @@ class Config(data.Container):
     Args:
     ----
         schema (Schema): The schema associated with the configuration.
-        allow_empty (bool, optional): Allow empty configuration. Defaults to False.
-        __data__ (dict | None, optional): The data for the configuration.
-            Defaults to None.
+        _data (dict | None, optional): The data for the configuration. Defaults to None.
         **kwargs: Additional keyword arguments for the configuration.
 
     Example:
@@ -55,21 +51,7 @@ class Config(data.Container):
         self,
         schema: Schema,
         _data: dict | None = None,
-        include_defaults: bool = True,
         **kwargs: Any,
     ) -> None:
         self.__schema__ = schema
-
-        for flag in get_flags(schema, _data):
-            if flag.flag in kwargs:
-                self[flag.key] = flag.convert(kwargs[flag.flag])
-            elif flag.value is not None:
-                self[flag.key] = flag.convert(flag.value)
-            elif flag.default is not None and include_defaults:
-                self[flag.key] = flag.convert(flag.default)
-
-    def set_defaults(self) -> None:
-        """Updates the configuration from keyword arguments"""
-        for flag in get_flags(self.__schema__):
-            if flag.default is not None and flag.key not in self:
-                self[flag.key] = flag.convert(flag.default)
+        super().__init__(_data=_data, **kwargs)

--- a/src/cellophane/cfg/jsonschema_.py
+++ b/src/cellophane/cfg/jsonschema_.py
@@ -121,10 +121,7 @@ def properties_(
                 "enum": subschema.get("enum"),
                 "description": subschema.get("description"),
                 "secret": subschema.get("secret", False),
-                "items_type": subschema.get("items", {}).get("type"),
-                "items_format": subschema.get("items", {}).get("format"),
-                "items_min": subschema.get("items", {}).get("minimum"),
-                "items_max": subschema.get("items", {}).get("maximum"),
+                "items": subschema.get("items"),
                 "format": subschema.get("format"),
                 "pattern": subschema.get("pattern"),
                 "min": subschema.get("minimum"),
@@ -157,11 +154,11 @@ def required_(
     if instance is not None:
         for prop in required:
             subschema = schema.get("properties", {}).get(prop)
-            if not (
-                subschema is None
-                or "default" in subschema
-                or "properties" in subschema
-                or prop in instance
+            if (
+                subschema is not None
+                and "default" not in subschema
+                and "properties" not in subschema
+                and prop not in instance
             ):
                 key = (*(_path or ()), prop)
                 flags[key] = flags.get(key, Flag(key=key))
@@ -282,15 +279,15 @@ def if_(
 
 
 @singledispatch
-def get_flags(schema: data.Container, _data: Mapping | None = None) -> list[Flag]:
+def get_flags(schema: data.Container, data_: Mapping | None = None) -> list[Flag]:
     """Get the flags for a configuration schema."""
-    return get_flags(util.freeze(data.as_dict(schema)), util.freeze(_data))
+    return get_flags(util.freeze(data.as_dict(schema)), util.freeze(data_))
 
 
 @get_flags.register
 @cache
-def _(schema: frozendict, _data: frozendict | None = None) -> list[Flag]:
-    data_thawed = util.unfreeze(_data)
+def _(schema: frozendict, data_: frozendict | None = None) -> list[Flag]:
+    data_thawed = util.unfreeze(data_)
     schema_thawed = util.unfreeze(schema)
     flags: dict[tuple[str, ...], Flag] = {}
 

--- a/src/cellophane/cfg/util.py
+++ b/src/cellophane/cfg/util.py
@@ -12,6 +12,19 @@ from cellophane import data
 class _BLANK:
     """Represents a blank value in YAML"""
 
+def extract_parens(value: str, open: str = "(", close: str = ")") -> str:
+    _iter = iter(value)
+    _counter = 0
+    _idx = 0
+    while char := next(_iter, None):
+        _counter += (char == open) - (char == close)
+        if _counter == 0:
+            break
+        _idx += 1
+    if _idx == 0 or _counter != 0:
+        raise ValueError(f"Invalid value: {value}")
+    return value[1:_idx]
+
 
 def dump_yaml(data_: Any) -> str:
     """Dumps data to a YAML string"""

--- a/tests/lib/integration/cfg.yaml
+++ b/tests/lib/integration/cfg.yaml
@@ -37,7 +37,7 @@
     --a: "INVALID"
     --workdir: out
   exception: |-
-    BadParameter("'INVALID' is not a valid float.")
+    BadParameter("'INVALID' is not a valid float range.")
 
 - id: bad_format
   structure:
@@ -84,7 +84,7 @@
     --a: "INVALID"
     --workdir: out
   exception: |-
-    BadParameter('Expected a comma separated mapping (a=b,x=y), got INVALID')
+    BadParameter('Expected a mapping (a=b,x=y), got INVALID')
 
 - id: bad_item_type
   structure:
@@ -95,10 +95,10 @@
           items:
             type: number
   args:
-    --a: !!python/tuple ["INVALID"]
+    --a: '"INVALID"'
     --workdir: out
   exception: |-
-    BadParameter("could not convert string to float: 'INVALID'")
+    BadParameter("Unable to convert value: 'INVALID' is not a valid float range.")
 
 - id: invalid_item_type
   structure:
@@ -146,7 +146,7 @@
     --a: "INVALID"
     --workdir: out
   exception: |-
-    BadParameter("'INVALID' does not match pattern: '^[a-z]+$'")
+    BadParameter("'INVALID' does not match pattern '^[a-z]+$'")
 
 - &parse_config
   id: parse_config
@@ -216,8 +216,8 @@
       boolean:
         a: true
         b: false
-      typed_array: [1, 3, 3, 7]
-      array: [1, 3, 3, 7]
+      typed_array: ["1", 3.0, "3.0", 7]
+      array: ["1", 3.0, "3.0", 7]
       mapping:
         a: "a"
         b: 1
@@ -245,9 +245,9 @@
   - key='typed_array' i=3 v=7 (int)
   - key='array' (list)
   - key='array' i=0 v='1' (str)
-  - key='array' i=1 v='3' (str)
-  - key='array' i=2 v='3' (str)
-  - key='array' i=3 v='7' (str)
+  - key='array' i=1 v=3.0 (float)
+  - key='array' i=2 v='3.0' (str)
+  - key='array' i=3 v=7 (int)
   - key='mapping' (PreservedDict)
   - key='mapping' k='a' v='a' (str)
   - key='mapping' k='b' v=1 (int)
@@ -267,8 +267,8 @@
     --integer: "1"
     --boolean_a: ~
     --boolean_no_b: ~
-    --typed_array: !!python/tuple [1, 3, 3, 7]
-    --array: !!python/tuple [1, 3, 3, 7]
+    --typed_array: "'1',3.0,'3.0',7"
+    --array: "'1',3.0,'3.0',7"
     --mapping: a="a",b=1,c=1.0,d.e="e",d.f=42
     --path: "path/to/file"
     --size: "1 GB"

--- a/tests/lib/schema/config/from_cli.yaml
+++ b/tests/lib/schema/config/from_cli.yaml
@@ -12,8 +12,6 @@ schema:
       type: boolean
     array:
       type: array
-      items:
-        type: string
     typed_array:
       type: array
       items:
@@ -35,16 +33,23 @@ schema:
               properties:
                 c:
                   type: string
+    nested_array:
+      type: array
+      items:
+        type: array
+        items:
+          type: string
 
 cli: [
   "--string", "STRING",
   "--integer", "1337",
   "--number", "13.37",
   "--boolean",
-  "--array", ["one", "two", "three"],
-  "--typed_array", ["1.0", "2.0", "3.0"],
-  "--mapping_array", ["a=X", "b=Y"],
-  "--mapping", "a=X,b=Y",
+  "--array", '"one","two","three"',
+  "--typed_array", '"1.0","2.0","3.0"',
+  "--mapping_array", '(a=X,b=Y),(c=X,d=Y)',
+  "--nested_array", "(a,b),(c,d)",
+  "--mapping", 'a=X,b=Y',
   "--nested_a_b_c", "Z"
 ]
 
@@ -63,7 +68,9 @@ config:
   - 3.0
   mapping_array:
   - a: "X"
-  - b: "Y"
+    b: "Y"
+  - c: "X"
+    d: "Y"
   mapping:
     a: "X"
     b: "Y"
@@ -71,3 +78,8 @@ config:
     a:
       b:
         c: "Z"
+  nested_array:
+  - - a
+    - b
+  - - c
+    - d

--- a/tests/lib/schema/config/from_data.yaml
+++ b/tests/lib/schema/config/from_data.yaml
@@ -35,6 +35,12 @@ schema:
               properties:
                 c:
                   type: string
+    nested_array:
+      type: array
+      items:
+        type: array
+        items:
+          type: string
 
 data: &data
   string: "STRING"
@@ -51,7 +57,9 @@ data: &data
   - 3.0
   mapping_array:
   - a: "X"
-  - b: "Y"
+    b: "Y"
+  - c: "X"
+    d: "Y"
   mapping:
     a: "X"
     b: "Y"
@@ -59,6 +67,11 @@ data: &data
     a:
       b:
         c: "Z"
+  nested_array:
+  - - "a"
+    - "b"
+  - - "c"
+    - "d"
 
 config:
   <<: *data

--- a/tests/lib/schema/config/from_kwargs.yaml
+++ b/tests/lib/schema/config/from_kwargs.yaml
@@ -35,6 +35,12 @@ schema: &schema
               properties:
                 c:
                   type: string
+    nested_array:
+      type: array
+      items:
+        type: array
+        items:
+          type: string
 
 kwargs:
   string: "STRING"
@@ -51,11 +57,18 @@ kwargs:
   - 3.0
   mapping_array:
   - a: "X"
-  - b: "Y"
+    b: "Y"
+  - c: "X"
+    d: "Y"
   mapping:
     a: "X"
     b: "Y"
   nested_a_b_c: "Z"
+  nested_array:
+  - - "a"
+    - "b"
+  - - "c"
+    - "d"
 
 config:
   string: "STRING"
@@ -72,7 +85,9 @@ config:
   - 3.0
   mapping_array:
   - a: "X"
-  - b: "Y"
+    b: "Y"
+  - c: "X"
+    d: "Y"
   mapping:
     a: "X"
     b: "Y"
@@ -80,4 +95,9 @@ config:
     a:
       b:
         c: "Z"
+  nested_array:
+  - - "a"
+    - "b"
+  - - "c"
+    - "d"
 

--- a/tests/lib/schema/flags/typed_array.yaml
+++ b/tests/lib/schema/flags/typed_array.yaml
@@ -14,4 +14,5 @@ flags:
   - key: !!python/tuple [a]
     type: array
     value: [a, b, c]
-    items_type: path
+    items:
+      type: path


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Refactor several aspects of the configuration system.

### The Why
Configuration was very convoluted, and inconsistent. For example, there was no way of specifying an array on the CLI, and some options would be interpreted different depending on if they were given on the command line or in a config file.

### The How
- Reduce unnecessary calls to `.convert` on click parameters
- Simplify the `cfg.Config` to essentially an alias of `data.Container`
- Implement a scanner of the array parameter type (similar to the mapping type)
- Add support for parentheses for the array and mapping types to facilitate nested mappings/arrays
- Ensure parameters are interpreted the same regardless of if they are specified as CLI options or in a `.yaml` config file
- Support all `items` options for array type (format, type, min, max etc.) including for nested typed arrays of any depth

There is still a lot of room for improvement in the configuration system, but this is at the very least a push in the right direction.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
