### PR TITLE
fix: Ensure mixed-case flags are correctly interpreted

### DIFF
--- a/src/cellophane/cfg/flag.py
+++ b/src/cellophane/cfg/flag.py
@@ -188,6 +188,7 @@ class Flag:
                 if self.type == "boolean"
                 else f"--{self.flag}"
             ),
+            self.flag,
             type=type_,
             default=True if self.type == "boolean" and default is None else default,
             required=self.required,

--- a/tests/lib/integration/cfg.yaml
+++ b/tests/lib/integration/cfg.yaml
@@ -208,6 +208,8 @@
           type: size
         no_type:
           default: "DEFAULT"
+        mIxEdCaSe:
+          type: string
     config.yaml: |
       string: "string"
       override: "CONFIG"
@@ -227,6 +229,7 @@
           f: 42
       path: "path/to/file"
       size: 1 GB
+      mIxEdCaSe: "MiXiTuP"
   args:
     --config_file: config.yaml
     --override: "CLI"
@@ -256,6 +259,7 @@
   - key='path' value=PosixPath('path/to/file') (PosixPath)
   - key='size' value=1000000000 (int)
   - key='no_type' value='DEFAULT' (str)
+  - key='mIxEdCaSe' value='MiXiTuP' (str)
 
 - <<: *parse_config
   id: parse_flags
@@ -272,3 +276,4 @@
     --mapping: a="a",b=1,c=1.0,d.e="e",d.f=42
     --path: "path/to/file"
     --size: "1 GB"
+    --mIxEdCaSe: "MiXiTuP"


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fixes the use of MiXeD CaSe flags, which were not included when building the config object.

### The Why
This was broken in the config overhaul and had no test-case. Click by default uses the lowercase version of the flag as the kwarg that will actually be passed to the callback. When cellophane then tries to match a kwarg to its corresponding flag, it fails as `flag.flag` may be uppercase or mixed case. 

### The How
Pass `flag.flag` as a second positional argument to the `click.option` decorator in `Flag.click_option`. This ensures that click will use the unmoddified version of `flag.flag` as the kwarg passed to the callback.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
