### PR TITLE
Logging improvements

### DIFF
--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -55,7 +55,7 @@ def cellophane(label: str, root: Path) -> click.Command:
     click.rich_click.REQUIRED_LONG_STRING = "(REQUIRED)"
     click.rich_click.DEFAULT_STRING = "{}"
     click.rich_click.STYLE_OPTION_DEFAULT = "green"
-    external_filter = ExternalFilter((CELLOPHANE_ROOT, root))
+    external_filter = ExternalFilter((CELLOPHANE_ROOT, root / "modules"))
     console_handler = setup_console_handler(filters=(external_filter,))
     logger = LoggerAdapter(getLogger(), {"label": label})
 

--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -89,13 +89,14 @@ def cellophane(label: str, root: Path) -> click.Command:
             """Run cellophane"""
             start_time = time.localtime()
             config.tag = config.get("tag", time.strftime("%y%m%d-%H%M%S", start_time))
+            config.logfile = config.logdir / f"{label}.{config.tag}.log"
 
             handle_warnings()
             console_handler.setLevel(config.log.level)
             file_handler = setup_file_handler(
-                config.logdir / f"{label}.{config.tag}.log",
+                config.logfile,
                 logger.logger,
-                filters=(external_filter,),
+                filters=(external_filter,)
             )
 
             if config.log.external:
@@ -167,6 +168,7 @@ def _main(
 
     cleaner = Cleaner(root=config.workdir / config.tag)
     cleaner.register(config.workdir / config.tag)
+    cleaner.register(config.logfile, ignore_outside_root=True)
 
     # Run pre-hooks
     samples = run_hooks(
@@ -222,6 +224,9 @@ def _main(
     # If there are failed samples, unregister the workdir from the cleaner
     if samples.failed or not config.clean:
         cleaner.unregister(config.workdir / config.tag)
+    if samples.failed or not config.log.clean:
+        cleaner.unregister(config.logfile)
+
     cleaner.clean(logger=logger)
     # If not post-hook has copied the outputs, warn the user
     if missing_outputs := [

--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -39,6 +39,7 @@ class Executor:
 
     name: ClassVar[str]
     config: cfg.Config
+    workdir_base: Path
     uuid: UUID = field(init=False)
 
     def __init_subclass__(
@@ -123,7 +124,7 @@ class Executor:
         logs.handle_warnings()
         logger = logging.LoggerAdapter(logging.getLogger(), {"label": name})
 
-        workdir_ = workdir or config.workdir / uuid.hex
+        workdir_ = workdir or self.workdir_base / f"{name}.{uuid.hex}.{self.name}"
         workdir_.mkdir(parents=True, exist_ok=True)
 
         env_ = env or {}

--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -142,13 +142,12 @@ class Executor:
                 data.PreservedDict,
                 lambda dumper, data: dumper.represent_dict(data)
             )
-            (workdir_ / "conda").mkdir(parents=True, exist_ok=True)
-            conda_env_spec = workdir_ / "conda" / f"{uuid.hex}.environment.yaml"
+            conda_env_spec = workdir_ / f"{name}.{uuid.hex}.environment.yaml"
             micromamba_bootstrap = _ROOT / "scripts" / "bootstrap_micromamba.sh"
             with open(conda_env_spec, "w") as f:
                 yaml.dump(conda_spec, f)
             env_["_CONDA_ENV_SPEC"] = str(conda_env_spec.relative_to(workdir_))
-            env_["_CONDA_ENV_NAME"] = f"{uuid.hex}"
+            env_["_CONDA_ENV_NAME"] = f"{name}.{uuid.hex}"
             args_ = (str(micromamba_bootstrap), *args_)
 
         try:
@@ -289,7 +288,7 @@ class Executor:
 
         """
         _uuid = uuid or uuid4()
-        _name = name or self.__class__.name
+        _name = name or f"{self.__class__.name}_job"
         logger = logging.LoggerAdapter(logging.getLogger(), {"label": _name})
         self.locks[_uuid] = mp.Lock()
         self.locks[_uuid].acquire()

--- a/src/cellophane/executors/subprocess_executor.py
+++ b/src/cellophane/executors/subprocess_executor.py
@@ -29,6 +29,8 @@ class SubprocessExecutor(Executor, name="subprocess"):
         env: dict,
         os_env: bool = True,
         logger: LoggerAdapter,
+        stdout: Path,
+        stderr: Path,
         **kwargs: Any,
     ) -> None:
         """Execute a command."""
@@ -37,15 +39,15 @@ class SubprocessExecutor(Executor, name="subprocess"):
         logdir.mkdir(parents=True, exist_ok=True)
 
         with (
-            open(workdir / f"{name}_{uuid.hex}.subprocess.out", "w", encoding="utf-8") as stdout,
-            open(workdir / f"{name}_{uuid.hex}.subprocess.err", "w", encoding="utf-8") as stderr,
+            open(stdout, "w", encoding="utf-8") as out,
+            open(stderr, "w", encoding="utf-8") as err
         ):
             proc = sp.Popen(  # nosec
                 shlex.split(shlex.join(args)),
                 cwd=workdir,
                 env=env | ({**os.environ} if os_env else {}),
-                stdout=stdout,
-                stderr=stderr,
+                stdout=out,
+                stderr=err,
                 start_new_session=True,
             )
             self.pids[uuid] = proc.pid

--- a/src/cellophane/executors/subprocess_executor.py
+++ b/src/cellophane/executors/subprocess_executor.py
@@ -23,6 +23,7 @@ class SubprocessExecutor(Executor, name="subprocess"):
     def target(
         self,
         *args: str,
+        name: str,
         uuid: UUID,
         workdir: Path,
         env: dict,
@@ -36,8 +37,8 @@ class SubprocessExecutor(Executor, name="subprocess"):
         logdir.mkdir(parents=True, exist_ok=True)
 
         with (
-            open(logdir / f"{uuid.hex}.out", "w", encoding="utf-8") as stdout,
-            open(logdir / f"{uuid.hex}.err", "w", encoding="utf-8") as stderr,
+            open(workdir / f"{name}_{uuid.hex}.subprocess.out", "w", encoding="utf-8") as stdout,
+            open(workdir / f"{name}_{uuid.hex}.subprocess.err", "w", encoding="utf-8") as stderr,
         ):
             proc = sp.Popen(  # nosec
                 shlex.split(shlex.join(args)),

--- a/src/cellophane/modules/hook.py
+++ b/src/cellophane/modules/hook.py
@@ -93,10 +93,11 @@ class Hook:
     ) -> Samples:
         logger = LoggerAdapter(getLogger(), {"label": self.label})
         logger.debug(f"Running {self.label} hook")
-
+        _workdir = config.workdir / config.tag
         with executor_cls(
             config=config,
             log_queue=log_queue,
+            workdir_base=_workdir,
         ) as executor:
             match self.func(
                 samples=samples,
@@ -104,7 +105,7 @@ class Hook:
                 timestamp=timestamp,
                 logger=logger,
                 root=root,
-                workdir=config.workdir / config.tag,
+                workdir=_workdir,
                 executor=executor,
                 cleaner=cleaner,
             ):

--- a/src/cellophane/modules/runner_.py
+++ b/src/cellophane/modules/runner_.py
@@ -73,6 +73,7 @@ class Runner:
         with executor_cls(
             config=config,
             log_queue=log_queue,
+            workdir_base=workdir,
         ) as executor:
             cleanup = partial(
                 _cleanup,

--- a/src/cellophane/schema.base.yaml
+++ b/src/cellophane/schema.base.yaml
@@ -23,6 +23,10 @@ properties:
         default: false
         description: Log messages from external libraries
         type: boolean
+      clean:
+        default: true
+        description: Remove main log file after successful pipeline run
+        type: boolean
 
   executor:
     type: object

--- a/src/cellophane/util/misc.py
+++ b/src/cellophane/util/misc.py
@@ -42,7 +42,7 @@ class freeze_logs:
     Example:
     -------
         ```python
-        with silence_logs():
+        with freeze_logs():
             logging.info("This will not be printed")
         ```
 

--- a/tests/test_integration/test_cleanup.py
+++ b/tests/test_integration/test_cleanup.py
@@ -108,7 +108,7 @@ class Test_cleanup(BaseTest):
     def test_cleanup_non_root(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
             "NON_ROOT outside out/DUMMY",
-            "Cleaning up 2 files and 1 directory",
+            "Cleaning up 3 files and 1 directory",
             "Removing 2 paths outside out/DUMMY",
             "out/DOES_NOT_EXIST does not exist",
             "Removing out/DUMMY",

--- a/tests/test_integration/test_executor.py
+++ b/tests/test_integration/test_executor.py
@@ -133,8 +133,8 @@ class Test_executor_submit(BaseTest):
     def test_executor_conda(self, invocation: Invocation) -> None:
         assert invocation.logs == regex(
             "bootstrap_micromamba\\.sh ping localhost -c 1",
-            f"env\\._CONDA_ENV_SPEC=conda/{UUID4_HEX_REGEX}\\.environment\\.yaml",
-            f"env\\._CONDA_ENV_NAME={UUID4_HEX_REGEX}",
+            f"env\\._CONDA_ENV_SPEC=mock_job.{UUID4_HEX_REGEX}\\.environment\\.yaml",
+            f"env\\._CONDA_ENV_NAME=mock_job.{UUID4_HEX_REGEX}",
         )
 
     @mark.override(


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Various improvements to logging, focusing on executor logging.

### The Why
Logging was difficult to follow, which made debugging crashes more involved than necessary. Also, debug logs of old invocations were kept indefinitely, requiring manual cleanup.

### The How
- Move executor stdout/stderr into the workdir of the executor rather than a separate location.
- Simplify and unify logging of executor exceptions.
- Remove redundant log calls.
- Add the wrapper log to the cleaner so that it is only kept if the wrapper fails.
- Ensure that the external filter only includes log calls from cellophane or `<PROJECT_DIR>/modules`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
