### PR TITLE
Hook checkpoints

### DIFF
--- a/src/cellophane/modules/hook.py
+++ b/src/cellophane/modules/hook.py
@@ -13,6 +13,8 @@ from cellophane.data import Samples
 from cellophane.executors import Executor
 from cellophane.util import Timestamp
 
+from .checkpoint import Checkpoints
+
 
 class _AFTER_ALL: ...
 
@@ -109,6 +111,11 @@ class Hook:
                 workdir=_workdir,
                 executor=executor,
                 cleaner=cleaner,
+                checkpoints=Checkpoints(
+                    samples=samples,
+                    workdir=config.workdir / config.tag,
+                    config=config,
+                ),
             ):
                 case returned if isinstance(returned, Samples):
                     _ret = returned

--- a/src/cellophane/modules/hook.py
+++ b/src/cellophane/modules/hook.py
@@ -113,6 +113,7 @@ class Hook:
                 cleaner=cleaner,
                 checkpoints=Checkpoints(
                     samples=samples,
+                    prefix=f"{self.when}-hook.{self.name}",
                     workdir=config.workdir / config.tag,
                     config=config,
                 ),

--- a/src/cellophane/modules/runner_.py
+++ b/src/cellophane/modules/runner_.py
@@ -95,6 +95,7 @@ class Runner:
                     cleaner=cleaner,
                     checkpoints=Checkpoints(
                         samples=samples,
+                        prefix=f"runner.{self.name}",
                         workdir=workdir,
                         config=config,
                     ),

--- a/tests/test_integration/test_checkpoint.py
+++ b/tests/test_integration/test_checkpoint.py
@@ -1,105 +1,18 @@
 from cellophane.testing import BaseTest, Invocation, literal
+from pytest import mark
 
 
 class Test_checkpoints(BaseTest):
     args = ["--workdir out", "--samples_file samples.yaml", "--tag DUMMY"]
     structure = {
-        "modules/a.py": """
-            from cellophane import runner, output, Output
+        "modules": {
+            "common.py": """
+                from cellophane import Sample
 
-            @output("out_a.txt", checkpoint="a")
-            @output("out_b*.txt", checkpoint="b")
-            @output("out_c_{sample.id}.txt", checkpoint="c")
-            @output("out_e", checkpoint="e")
-            @runner()
-            def runner_(samples, checkpoints, config, workdir, logger, **_):
-                a_1, hash_a_1 = checkpoints.a.check(), checkpoints.a.hexdigest()
-                (workdir / "out_a.txt").touch()
-                checkpoints.a.store()
-                a_2, hash_a_2 = checkpoints.a.check(), checkpoints.a.hexdigest()
-
-                (workdir / "out_b1.txt").touch()
-                checkpoints["b"].store()
-                b_1, hash_b_1 = checkpoints["b"].check(), checkpoints["b"].hexdigest()
-                (workdir / "out_b2.txt").touch()
-                b_2, hash_b_2 = checkpoints["b"].check(), checkpoints["b"].hexdigest()
-                (workdir / "out_b2.txt").write_text("UPDATED")
-                b_3, hash_b_3 = checkpoints["b"].check(), checkpoints["b"].hexdigest()
-
-                c_1, hash_c_1 = checkpoints.c.check(), checkpoints.c.hexdigest()
-                (workdir / f"out_c_{samples[0].id}.txt").touch()
-                checkpoints.c.store()
-                c_2, hash_c_2 = checkpoints.c.check(), checkpoints.c.hexdigest()
-                checkpoints.c.store()
-
-                d_1, hash_d_1 = checkpoints.d.check(), checkpoints.d.hexdigest()
-                (workdir / "out_d.txt").write_text("DUMMY_D")
-                d_2, hash_d_2 = checkpoints.d.check(), checkpoints.d.hexdigest()
-                samples.output.add(Output(src="out_d.txt", dst="out_d.txt", checkpoint="d"))
-                d_3, hash_d_3 = checkpoints.d.check(), checkpoints.d.hexdigest()
-
-                e_1, hash_e_1 = checkpoints.e.check(), checkpoints.e.hexdigest()
-                (workdir / "out_e").mkdir()
-                checkpoints.e.store()
-                e_2, hash_e_2 = checkpoints.e.check(), checkpoints.e.hexdigest()
-                for i in range(500):
-                    (workdir / f"out_e/{i}.txt").write_text(f"DUMMY FILE {i}")
-                (workdir / "out_e" / "subdir").mkdir()
-                for i in range(500):
-                    (workdir / f"out_e/subdir/{i}.txt").write_text(f"DUMMY FILE {i}")
-                e_3, hash_e_3 = checkpoints.e.check(), checkpoints.e.hexdigest()
-                checkpoints.e.store()
-                e_4, hash_e_4 = checkpoints.e.check(), checkpoints.e.hexdigest()
-
-
-                a_3, hash_a_3 = checkpoints.a.check(), checkpoints.a.hexdigest()
-
-                logger.info(f"{a_1=} (False)")
-                logger.info(f"{a_2=} (True)")
-                logger.info(f"{hash_a_1==hash_a_2=} (False)")
-                logger.info(f"{hash_a_2==hash_a_3=} (True)")
-
-                logger.debug(f"{hash_a_1=}")
-                logger.debug(f"{hash_a_2=}")
-                logger.debug(f"{hash_a_3=}")
-
-                logger.info(f"{b_1=} (True)")
-                logger.info(f"{b_2=} (False)")
-                logger.info(f"{b_3=} (False)")
-                logger.info(f"{hash_b_1==hash_b_2=} (False)")
-                logger.info(f"{hash_b_2==hash_b_3=} (False)")
-
-                logger.debug(f"{hash_b_1=}")
-                logger.debug(f"{hash_b_2=}")
-                logger.debug(f"{hash_b_3=}")
-
-                logger.info(f"{c_1=} (False)")
-                logger.info(f"{c_2=} (True)")
-                logger.info(f"{hash_c_1==hash_c_2=} (False)")
-
-                logger.debug(f"{hash_c_1=}")
-                logger.debug(f"{hash_c_2=}")
-
-                logger.info(f"{d_1=} (False)")
-                logger.info(f"{d_2=} (False)")
-                logger.info(f"{d_3=} (False)")
-                logger.info(f"{hash_d_1==hash_d_2=} (True)")
-                logger.info(f"{hash_d_2==hash_d_3=} (False)")
-
-                logger.debug(f"{hash_d_1=}")
-                logger.debug(f"{hash_d_2=}")
-                logger.debug(f"{hash_d_3=}")
-
-                logger.info(f"{e_1=} (False)")
-                logger.info(f"{e_2=} (True)")
-                logger.info(f"{e_3=} (False)")
-                logger.info(f"{e_4=} (True)")
-
-                logger.debug(f"{hash_e_1=}")
-                logger.debug(f"{hash_e_2=}")
-                logger.debug(f"{hash_e_3=}")
-                logger.debug(f"{hash_e_4=}")
-            """,
+                class TestSample(Sample):
+                    groupvar: str | None = None
+            """
+        },
         "samples.yaml": """
             - id: a
               files:
@@ -122,6 +35,131 @@ class Test_checkpoints(BaseTest):
         },
     }
 
+    @mark.override(
+        structure = {
+            **structure,
+            "modules/a.py": """
+                from cellophane import runner, output, Output
+
+                @output("out_a.txt", checkpoint="a")
+                @output("out_b*.txt", checkpoint="b")
+                @output("out_c_{sample.id}.txt", checkpoint="c")
+                @output("out_e", checkpoint="e")
+                @runner()
+                def runner_(samples, checkpoints, config, workdir, logger, **_):
+                    a_1, hash_a_1 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    (workdir / "out_a.txt").touch()
+                    checkpoints.a.store()
+                    a_2, hash_a_2 = checkpoints.a.check(), checkpoints.a.hexdigest()
+
+                    (workdir / "out_b1.txt").touch()
+                    checkpoints["b"].store()
+                    b_1, hash_b_1 = checkpoints["b"].check(), checkpoints["b"].hexdigest()
+                    (workdir / "out_b2.txt").touch()
+                    b_2, hash_b_2 = checkpoints["b"].check(), checkpoints["b"].hexdigest()
+                    (workdir / "out_b2.txt").write_text("UPDATED")
+                    b_3, hash_b_3 = checkpoints["b"].check(), checkpoints["b"].hexdigest()
+
+                    c_1, hash_c_1 = checkpoints.c.check(), checkpoints.c.hexdigest()
+                    (workdir / f"out_c_{samples[0].id}.txt").touch()
+                    checkpoints.c.store()
+                    c_2, hash_c_2 = checkpoints.c.check(), checkpoints.c.hexdigest()
+                    checkpoints.c.store()
+
+                    d_1, hash_d_1 = checkpoints.d.check(), checkpoints.d.hexdigest()
+                    (workdir / "out_d.txt").write_text("DUMMY_D")
+                    d_2, hash_d_2 = checkpoints.d.check(), checkpoints.d.hexdigest()
+                    samples.output.add(Output(src="out_d.txt", dst="out_d.txt", checkpoint="d"))
+                    d_3, hash_d_3 = checkpoints.d.check(), checkpoints.d.hexdigest()
+
+                    e_1, hash_e_1 = checkpoints.e.check(), checkpoints.e.hexdigest()
+                    (workdir / "out_e").mkdir()
+                    checkpoints.e.store()
+                    e_2, hash_e_2 = checkpoints.e.check(), checkpoints.e.hexdigest()
+                    for i in range(500):
+                        (workdir / f"out_e/{i}.txt").write_text(f"DUMMY FILE {i}")
+                    (workdir / "out_e" / "subdir").mkdir()
+                    for i in range(500):
+                        (workdir / f"out_e/subdir/{i}.txt").write_text(f"DUMMY FILE {i}")
+                    e_3, hash_e_3 = checkpoints.e.check(), checkpoints.e.hexdigest()
+                    checkpoints.e.store()
+                    e_4, hash_e_4 = checkpoints.e.check(), checkpoints.e.hexdigest()
+
+
+                    (workdir / "ext_f.txt").touch()
+                    checkpoints.f.add_paths(workdir / "ext_f.txt")
+                    f_1, hash_f_1 = checkpoints.f.check(), checkpoints.f.hexdigest()
+                    checkpoints.f.store()
+                    f_2, hash_f_2 = checkpoints.f.check(), checkpoints.f.hexdigest()
+                    (workdir / "ext_f.txt").write_text("UPDATED")
+                    f_3, hash_f_3 = checkpoints.f.check(), checkpoints.f.hexdigest()
+                    checkpoints.f.store()
+                    f_4, hash_f_4 = checkpoints.f.check(), checkpoints.f.hexdigest()
+
+                    a_3, hash_a_3 = checkpoints.a.check(), checkpoints.a.hexdigest()
+
+                    logger.info(f"{a_1=} (False)")
+                    logger.info(f"{a_2=} (True)")
+                    logger.info(f"{hash_a_1==hash_a_2=} (False)")
+                    logger.info(f"{hash_a_2==hash_a_3=} (True)")
+
+                    logger.debug(f"{hash_a_1=}")
+                    logger.debug(f"{hash_a_2=}")
+                    logger.debug(f"{hash_a_3=}")
+
+                    logger.info(f"{b_1=} (True)")
+                    logger.info(f"{b_2=} (False)")
+                    logger.info(f"{b_3=} (False)")
+                    logger.info(f"{hash_b_1==hash_b_2=} (False)")
+                    logger.info(f"{hash_b_2==hash_b_3=} (False)")
+
+                    logger.debug(f"{hash_b_1=}")
+                    logger.debug(f"{hash_b_2=}")
+                    logger.debug(f"{hash_b_3=}")
+
+                    logger.info(f"{c_1=} (False)")
+                    logger.info(f"{c_2=} (True)")
+                    logger.info(f"{hash_c_1==hash_c_2=} (False)")
+
+                    logger.debug(f"{hash_c_1=}")
+                    logger.debug(f"{hash_c_2=}")
+
+                    logger.info(f"{d_1=} (False)")
+                    logger.info(f"{d_2=} (False)")
+                    logger.info(f"{d_3=} (False)")
+                    logger.info(f"{hash_d_1==hash_d_2=} (True)")
+                    logger.info(f"{hash_d_2==hash_d_3=} (False)")
+
+                    logger.debug(f"{hash_d_1=}")
+                    logger.debug(f"{hash_d_2=}")
+                    logger.debug(f"{hash_d_3=}")
+
+                    logger.info(f"{e_1=} (False)")
+                    logger.info(f"{e_2=} (True)")
+                    logger.info(f"{e_3=} (False)")
+                    logger.info(f"{e_4=} (True)")
+
+                    logger.debug(f"{hash_e_1=}")
+                    logger.debug(f"{hash_e_2=}")
+                    logger.debug(f"{hash_e_3=}")
+                    logger.debug(f"{hash_e_4=}")
+
+                    logger.info(f"{f_1=} (False)")
+                    logger.info(f"{f_2=} (True)")
+                    logger.info(f"{f_3=} (False)")
+                    logger.info(f"{f_4=} (True)")
+
+                    logger.info(f"{hash_f_1==hash_f_2=} (True)")
+                    logger.info(f"{hash_f_2==hash_f_3=} (False)")
+                    logger.info(f"{hash_f_3==hash_f_4=} (True)")
+
+                    logger.debug(f"{hash_f_1=}")
+                    logger.debug(f"{hash_f_2=}")
+                    logger.debug(f"{hash_f_3=}")
+                    logger.debug(f"{hash_f_4=}")
+                """,
+        }
+    )
     def test_checkpoints(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
             "a_1=False (False)",
@@ -145,4 +183,87 @@ class Test_checkpoints(BaseTest):
             "e_2=True (True)",
             "e_3=False (False)",
             "e_4=True (True)",
+            "f_1=False (False)",
+            "f_2=True (True)",
+            "f_3=False (False)",
+            "f_4=True (True)",
+            "hash_f_1==hash_f_2=True (True)",
+            "hash_f_2==hash_f_3=False (False)",
+            "hash_f_3==hash_f_4=True (True)",
+        )
+
+    @mark.override(
+        structure = {
+            **structure,
+            "modules/a.py": """
+                from cellophane import pre_hook, Samples
+                from copy import deepcopy
+
+                @pre_hook()
+                def runner_a(logger, samples, checkpoints, workdir, **_):
+                    a_1, hash_a_1 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    checkpoints.a.store()
+                    a_2, hash_a_2 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    checkpoints.a.store()
+                    a_3, hash_a_3 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    (workdir / "ext_a.txt").touch()
+                    checkpoints.a.paths = [workdir / "ext_a.txt"]
+                    logger.critical(checkpoints.a.paths)
+                    a_4, hash_a_4 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    checkpoints.a.store()
+                    a_5, hash_a_5 = checkpoints.a.check(), checkpoints.a.hexdigest()
+
+                    checkpoints.a.samples = deepcopy(samples)
+                    checkpoints.a.store()
+                    a_6, hash_a_6 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    (workdir / "mod.txt").write_text("UPDATED")
+                    samples[0].files = [workdir / "mod.txt"]
+                    a_7, hash_a_7 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    checkpoints.a.samples[0].files = [workdir / "mod.txt"]
+                    a_8, hash_a_8 = checkpoints.a.check(), checkpoints.a.hexdigest()
+                    checkpoints.a.store()
+                    a_9, hash_a_9 = checkpoints.a.check(), checkpoints.a.hexdigest()
+
+                    logger.info(f"{a_1=} (False)")
+                    logger.info(f"{a_2=} (True)")
+                    logger.info(f"{a_3=} (True)")
+                    logger.info(f"{a_4=} (False)")
+                    logger.info(f"{a_5=} (True)")
+                    logger.info(f"{a_6=} (True)")
+                    logger.info(f"{a_7=} (True)")
+                    logger.info(f"{a_8=} (False)")
+                    logger.info(f"{a_9=} (True)")
+
+                    logger.info(f"{hash_a_1==hash_a_2=} (True)")
+                    logger.info(f"{hash_a_2==hash_a_3=} (True)")
+                    logger.info(f"{hash_a_3==hash_a_4=} (False)")
+                    logger.info(f"{hash_a_4==hash_a_5=} (True)")
+                    logger.info(f"{hash_a_5==hash_a_6=} (True)")
+                    logger.info(f"{hash_a_6==hash_a_7=} (True)")
+                    logger.info(f"{hash_a_7==hash_a_8=} (False)")
+                    logger.info(f"{hash_a_8==hash_a_9=} (True)")
+
+                    logger.debug(f"{hash_a_1=}")
+                    logger.debug(f"{hash_a_2=}")
+                    logger.debug(f"{hash_a_3=}")
+                    logger.debug(f"{hash_a_4=}")
+                    logger.debug(f"{hash_a_5=}")
+                    logger.debug(f"{hash_a_6=}")
+                    logger.debug(f"{hash_a_7=}")
+                    logger.debug(f"{hash_a_8=}")
+                    logger.debug(f"{hash_a_9=}")
+                """,
+        }
+    )
+    def test_hook_checkpoints(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal(
+            "a_1=False (False)",
+            "a_2=True (True)",
+            "a_3=True (True)",
+            "a_4=False (False)",
+            "a_5=True (True)",
+            "hash_a_1==hash_a_2=True (True)",
+            "hash_a_2==hash_a_3=True (True)",
+            "hash_a_3==hash_a_4=False (False)",
+            "hash_a_4==hash_a_5=True (True)",
         )


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Allow hooks to use checkpoints.

### The Why
Currently, there is no way for a hook to checkpoint its progress. This is particularly bad when a checkpoint updates the files of a sample, as this will invalidate any downstream checkpoint. 

### The How
- Pass `checkpoints` to each hook as a kwarg with a `cellophane.Checkpoints` object.
- Save the checkpoints files to a `config.workdir / config.tag / "checkpoints"` rather than the active hook/runner workdir.
- Name the checkpoint file `<runner/pre-hook/post-hook>.<hook/runner name>.<checkpoint label>.json` to avoid collisions.
- Add an `add_paths` method to the `Checkpoint` class to manually add paths to a checkpoint.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
