### PR TITLE
fix: Ensure executor can represent data.PreservedDict

### DIFF
--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -19,7 +19,7 @@ from mpire.async_result import AsyncResult
 from mpire.exception import InterruptWorker
 from ruamel.yaml import YAML
 
-from cellophane import cfg, logs
+from cellophane import cfg, data, logs
 
 _LOCKS: dict[UUID, dict[UUID, Lock]] = {}
 _POOLS: dict[UUID, WorkerPool] = {}
@@ -130,6 +130,10 @@ class Executor:
         args_ = tuple(word for arg in args for word in shlex.split(str(arg)))
         if conda_spec:
             yaml = YAML(typ="safe")
+            yaml.representer.add_representer(
+                data.PreservedDict,
+                lambda dumper, data: dumper.represent_dict(data)
+            )
             (workdir_ / "conda").mkdir(parents=True, exist_ok=True)
             conda_env_spec = workdir_ / "conda" / f"{uuid.hex}.environment.yaml"
             micromamba_bootstrap = _ROOT / "scripts" / "bootstrap_micromamba.sh"


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Ensure executor can dump `data.PreservedDict`.

### The Why
`Executor.submit` crashes if `conda_spec` contains `data.PreservedDict` (i.e. if it was specified as a mapping in the config).

### The How
Set the representer for `data.PreservedDict` to `represent_dict`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
