### PR TITLE
Fix dev cli

### DIFF
--- a/src/cellophane/dev/cli.py
+++ b/src/cellophane/dev/cli.py
@@ -188,7 +188,7 @@ def module_action(
                     add_paths=[
                         "modules/requirements.txt",
                         "config.example.yaml",
-                        *([f"modules/{module_path.name}"] if new_action != "rm" else []),
+                        *([f"modules/{module_dir_name}"] if new_action != "rm" else []),
                     ],
                     trailers={
                         "CellophaneAction": "module",

--- a/src/cellophane/dev/cli.py
+++ b/src/cellophane/dev/cli.py
@@ -184,6 +184,7 @@ def module_action(
             if new_action is not None:
                 commit_changes(
                     index=index,
+                    repo=repo,
                     msg=msg[new_action],
                     add_paths=[
                         "modules/requirements.txt",
@@ -235,13 +236,14 @@ def update(ctx: click.Context) -> None:
         drop_local_commits(repo, index, logger, action="update")
         update_requirements(ctx.obj["path"])
         update_example_config(ctx.obj["path"])
-        index.add(["modules/requirements.txt", "config.example.yaml"])
+        repo.git.add(["modules/requirements.txt", "config.example.yaml"])
         if not index.diff("HEAD", ["modules/requirements.txt", "config.example.yaml"]):
             logger.info("No changes detected")
             index.reset(previous_head, index=True, working_tree=True)
             return
         commit_changes(
             index=index,
+            repo=repo,
             msg="Update requirements and example configuration",
             add_paths=["modules/requirements.txt", "config.example.yaml"],
             trailers={"CellophaneAction": "update"},

--- a/src/cellophane/dev/util.py
+++ b/src/cellophane/dev/util.py
@@ -263,8 +263,7 @@ def initialize_project(
     update_example_config(path)
 
     repo = Repo.init(str(path))
-    index = repo.index
-    index.add(
+    repo.git.add(
         [
             path / "modules" / "__init__.py",
             path / "modules" / "requirements.txt",
@@ -276,8 +275,7 @@ def initialize_project(
             path / ".gitignore",
         ],
     )
-    index.write()
-    index.commit("feat(cellophane): Initial commit from cellophane 🎉")
+    repo.index.commit("feat(cellophane): Initial commit from cellophane 🎉")
 
     return ProjectRepo(path, modules_repo_url, modules_repo_branch)
 
@@ -375,6 +373,7 @@ def rewrite_action(
 
 def commit_changes(
     index: IndexFile,
+    repo: Repo,
     msg: str,
     trailers: dict[str, str],
     add_paths: list[str] | None = None,
@@ -390,12 +389,7 @@ def commit_changes(
         add_paths (Sequence[str]): The paths to add to the commit.
         logger (logging.LoggerAdapter): The logger instance.
     """
-    for path in add_paths or []:
-        index.add(path)
-    index.add("config.example.yaml")
-    index.add("modules/requirements.txt")
-    index.write()
-
+    repo.git.add(*(add_paths or []), "config.example.yaml", "modules/requirements.txt")
     _trailers = "\n".join(f"{k}: {v}" for k, v in trailers.items())
     _msg = f"chore(cellophane): {msg}\n\n{_trailers}"
     index.commit(dedent(_msg).strip())

--- a/src/cellophane/dev/util.py
+++ b/src/cellophane/dev/util.py
@@ -98,7 +98,7 @@ def ask_version(module_: str, valid_versions: Iterable[tuple[str, str]]) -> tupl
 
     _versions = select(
         f"Select version for {module_}",
-        choices=[Choice(title=version, value=(tag, version)) for version, tag in valid_versions],
+        choices=[Choice(title=version, value=(version, tag)) for version, tag in valid_versions],
         erase_when_done=True,
     ).ask()
     Console().show_cursor()

--- a/tests/test_dev/fixtures.py
+++ b/tests/test_dev/fixtures.py
@@ -46,18 +46,18 @@ def modules_repo_path(tmp_path_factory: TempPathFactory) -> Iterator[Path]:
     modules_json["d"]["path"] = "modules/SOME_OTHER_PATH/"
     with open(path / "modules.json", "w") as file:
         json.dump(modules_json, file)
-    repo.index.add("**")
+    repo.git.add("**")
     repo.index.commit("Initial commit")
     for module in ("a", "b", "c", "d"):
         dir_name = module if module != "d" else "SOME_OTHER_PATH"
         (path / "modules" / dir_name).mkdir(parents=True)
         (path / "modules" / dir_name / module.upper()).write_text("1.0.0")
         (path / "modules" / dir_name / "requirements.txt").write_text("foo==1.0.0")
-        repo.index.add(f"modules/{dir_name}")
+        repo.git.add(f"modules/{dir_name}")
         repo.index.commit(f"Add module {module}/1.0.0")
         repo.create_tag(f"{module}/1.0.0")
         (path / "modules" / dir_name / module.upper()).write_text("2.0.0")
-        repo.index.add(f"modules/{dir_name}")
+        repo.git.add(f"modules/{dir_name}")
         repo.index.commit(f"Update module {module}/2.0.0")
         repo.create_tag(f"{module}/2.0.0")
     repo.create_head("dev")


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fix various bugs in the dev CLI

### The Why
There were various bugs in the dev CLI

### The How
- Ensure module dir name is actually used (rather than module name) when adding modules
- Replace `repo.index.add` with `repo.git.add` to avoid extra files being included
- Fix tag/name being switched in `ask_version`

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
