### PR TITLE
fix: Remove leading 'modules' in requirements paths

### DIFF
--- a/src/cellophane/dev/util.py
+++ b/src/cellophane/dev/util.py
@@ -36,7 +36,7 @@ def update_requirements(path: Path) -> None:
             .read_text(encoding="utf-8")
         )
         handle.writelines(
-            f"-r {req.relative_to(path)}\n"
+            f"-r {req.relative_to(path / 'modules')}\n"
             for req in (path / "modules").glob("*/requirements.txt")
         )
 

--- a/tests/test_dev/test_dev.py
+++ b/tests/test_dev/test_dev.py
@@ -532,7 +532,7 @@ class Test_project_cli:
         )
         self.runner.invoke(dev.main, "project update")
         assert (path / "modules" / "requirements.txt").read_text() == literal(
-            "\n-r modules/mymodule/requirements.txt\n"
+            "\n-r mymodule/requirements.txt\n"
         )
 
     def test_project_update_invalid_repo(


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Remove incorrect leading 'modules' from paths in 'modules/requirements.txt'

### The Why
This broke `pip install -r requirements.txt`

### The How
Write the path relative to `path / "modules"` rather than relative to `path` in `update_requirements`

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
