### PR TITLE
Fix cleaner unreg logfile

### DIFF
--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -225,7 +225,7 @@ def _main(
     if samples.failed or not config.clean:
         cleaner.unregister(config.workdir / config.tag)
     if samples.failed or not config.log.clean:
-        cleaner.unregister(config.logfile)
+        cleaner.unregister(config.logfile, ignore_outside_root=True)
 
     cleaner.clean(logger=logger)
     # If not post-hook has copied the outputs, warn the user


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Allow the main log to be unregistered from cleaner despite being outside the project root

### The Why
Paths outside the cleaner root need to be explicitly allowed to be registered or unregistered from the cleaner. Currently, the register call is allowed, but not the unregister call, so the log is always cleaned.

### The How
Add `allow_outside_root=True` to the unregister call.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
