### PR TITLE
fix: Add label for logs from warnings

### DIFF
--- a/src/cellophane/logs/util.py
+++ b/src/cellophane/logs/util.py
@@ -54,6 +54,7 @@ def _showwarning(showwarning_orig: Callable) -> Callable:
             func=stack[2].function,
             args=(),
             exc_info=None,
+            extra={"label": "warnings"},
         )
         logger.handle(record)
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Add a `warnings` label to logs from warnings

### The Why
They were labeled as `unknown` before, which was a bit ugly

### The How
Pass `extra={"label": "warnings"}` to `logger.makeRecord`

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
