### PR TITLE
Refactor checkpoints

### DIFF
--- a/src/cellophane/modules/checkpoint.py
+++ b/src/cellophane/modules/checkpoint.py
@@ -66,6 +66,7 @@ class Checkpoint:
                     # Only src is considered, so using the current time works
                     # since timestamps are never included in src paths
                     timestamp=Timestamp(),
+                    _warnings=False,
                 )
                 output_paths = {o.src for o in outputs}
 

--- a/src/cellophane/modules/checkpoint.py
+++ b/src/cellophane/modules/checkpoint.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from pathlib import Path
 from random import randbytes
 from typing import Any, Iterator, Sequence
+from warnings import warn
 
 from attrs import define, field
 from dill import dumps
@@ -38,6 +39,7 @@ class Checkpoint:
     prefix: str
     base_path: Path
     file: Path = field(init=False)
+    params: list = field(factory=list)
     _cache: dict[str, str] | None = field(init=False)
     _extra_paths: set[Path] = field(factory=set)
 
@@ -121,9 +123,18 @@ class Checkpoint:
             tuple[str, bytes]: The name of the file and the hash.
 
         """
+        _params = self.params.copy()
+        if args or kwargs:
+            _params.extend(args)
+            _params.append(kwargs)
+            warn(
+                "Passing args or kwargs to store() is deprecated and will be removed in a future version. "
+                "Append any extra parameters for a checkpoint to the `checkpoint.params` attribute before "
+                "calling `checkpoint.store()` instead",
+            )
+
         base = xxh3_64()
-        base.update(dumps(args))
-        base.update(dumps(kwargs))
+        base.update(dumps(_params))
         base.update(self.label.encode())
 
         for path in self._paths:

--- a/src/cellophane/modules/runner_.py
+++ b/src/cellophane/modules/runner_.py
@@ -63,6 +63,7 @@ class Runner:
         executor_cls: type[Executor],
         timestamp: Timestamp,
         workdir: Path,
+        checkpoints: Checkpoints | None = None,
     ) -> tuple[Samples, DeferredCleaner]:
         handle_warnings()
         redirect_logging_to_queue(log_queue)
@@ -93,12 +94,7 @@ class Runner:
                     workdir=workdir,
                     executor=executor,
                     cleaner=cleaner,
-                    checkpoints=Checkpoints(
-                        samples=samples,
-                        prefix=f"runner.{self.name}",
-                        workdir=workdir,
-                        config=config,
-                    ),
+                    checkpoints=checkpoints,
                 ):
                     case None:
                         logger.debug("Runner did not return any samples")
@@ -260,6 +256,12 @@ def start_runners(
                         "executor_cls": executor_cls,
                         "timestamp": timestamp,
                         "workdir": workdir,
+                        "checkpoints": Checkpoints(
+                            samples=samples_,
+                            prefix=f"runner.{runner_.name}.{group}" if group else f"runner.{runner_.name}",
+                            workdir=workdir,
+                            config=config,
+                        )
                     },
                 )
                 results.append(result)

--- a/tests/test_integration/test_checkpoint.py
+++ b/tests/test_integration/test_checkpoint.py
@@ -96,6 +96,14 @@ class Test_checkpoints(BaseTest):
                     checkpoints.f.store()
                     f_4, hash_f_4 = checkpoints.f.check(), checkpoints.f.hexdigest()
 
+                    checkpoints.g.params = ["SOME_PARAMETER"]
+                    checkpoints.g.store()
+                    g_1, hash_g_1 = checkpoints.g.check(), checkpoints.g.hexdigest()
+                    checkpoints.g.params = ["SOME_OTHER_PARAMETER"]
+                    g_2, hash_g_2 = checkpoints.g.check(), checkpoints.g.hexdigest()
+                    checkpoints.g.params = ["SOME_PARAMETER"]
+                    g_3, hash_g_3 = checkpoints.g.check(), checkpoints.g.hexdigest()
+
                     a_3, hash_a_3 = checkpoints.a.check(), checkpoints.a.hexdigest()
 
                     logger.info(f"{a_1=} (False)")
@@ -157,6 +165,16 @@ class Test_checkpoints(BaseTest):
                     logger.debug(f"{hash_f_2=}")
                     logger.debug(f"{hash_f_3=}")
                     logger.debug(f"{hash_f_4=}")
+
+                    logger.info(f"{g_1=} (True)")
+                    logger.info(f"{g_2=} (False)")
+                    logger.info(f"{g_3=} (True)")
+                    logger.info(f"{hash_g_1==hash_g_2=} (False)")
+                    logger.info(f"{hash_g_2==hash_g_3=} (False)")
+                    logger.info(f"{hash_g_3==hash_g_1=} (True)")
+                    logger.debug(f"{hash_g_1=}")
+                    logger.debug(f"{hash_g_2=}")
+                    logger.debug(f"{hash_g_3=}")
                 """,
         }
     )
@@ -190,6 +208,12 @@ class Test_checkpoints(BaseTest):
             "hash_f_1==hash_f_2=True (True)",
             "hash_f_2==hash_f_3=False (False)",
             "hash_f_3==hash_f_4=True (True)",
+            "g_1=True (True)",
+            "g_2=False (False)",
+            "g_3=True (True)",
+            "hash_g_1==hash_g_2=False (False)",
+            "hash_g_2==hash_g_3=False (False)",
+            "hash_g_3==hash_g_1=True (True)",
         )
 
     @mark.override(


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Additional refactorings of checkpoints.

### The Why
- Storing/Checking checkpoints would throw warnings about missing outputs.
- Storing/checking checkpoints with extra parameters was very confusing.
- Checkpoint filenames would collide for runners with `split_by` specified.

### The How
- Add option to silence warnings
- Add `params` property to `Checkpoint` and throw a deprecation notice if users pass args/kwargs to `Checkpoint.check`/`Checkpoint.store`
- Included the group variable in file name if runner splits samples


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
