### PR TITLE
fix: Ensure 'Checkpoint.params' is a list

### DIFF
--- a/src/cellophane/modules/checkpoint.py
+++ b/src/cellophane/modules/checkpoint.py
@@ -39,7 +39,7 @@ class Checkpoint:
     prefix: str
     base_path: Path
     file: Path = field(init=False)
-    params: list = field(factory=list)
+    _params: list = field(factory=list)
     _cache: dict[str, str] | None = field(init=False)
     _extra_paths: set[Path] = field(factory=set)
 
@@ -100,6 +100,14 @@ class Checkpoint:
         self._samples = samples
         with suppress(AttributeError):
             del self._paths
+
+    @property
+    def params(self) -> list:
+        return self._params
+
+    @params.setter
+    def params(self, params: Any | list) -> None:
+        self._params = params if isinstance(params, list) else [params]
 
     def _hash(self, *args: Any, **kwargs: Any) -> Iterator[tuple[str, str]]:
         """Generate a hash for the samples.


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Ensure `Checkpoint.params` is a list

### The Why
`Checkpoint.check` and `Checkpoint.store` will crash if `Checkpoint.params` is not a list. More specifically, if it doesn't have a `.copy` method.

### The How
Create a `property` with a custom setter that will ensure the value is always a list.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
