### PR TITLE
chore: Add 'cellophane' as script in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,13 @@ branch = false
 [tool.coverage.report]
 omit = ["**/pytest-*/*"]
 
+
+
+[project.scripts]
+cellophane = "cellophane.dev:main"
+
+
+
 [tool.ruff]
 line-length = 88
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Adds 'cellophane' as a script

### The Why
Easy access to the cellophane development CLI

### The How
Add cellophane script definition in `pyproject.toml` pointing at cellophane.dev:main

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
