### PR TITLE
fix: New signature for 'get_metavar' in click 8.2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Library for wrappers integrating with SLIMS"
 authors = [{name = "Erik Demitz-Helin",email = "erik.demitz-helin@gu.se"}]
 readme = "README.md"
 dependencies = [
-    "click>=8.1.3,<9.0.0",
+    "click>=8.2.0,<9.0.0",
     "psutil>=5.9.4,<6.0.0",
-    "rich-click>=1.6.0,<2.0.0",
+    "rich-click>=1.8.9,<2.0.0",
     "humanfriendly>=10.0,<11.0",
     "jsonschema>=4.17.3,<5.0.0",
     "attrs>=23.1.0,<24.0.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -18,11 +18,11 @@ attrs==23.2.0
     # via referencing
 bandit==1.7.10
 black==22.12.0
-click==8.1.7
+click==8.2.1
     # via black
     # via cellophane
     # via rich-click
-colorama==0.4.6 ; sys_platform == 'win32'
+colorama==0.4.6 ; platform_system == 'Windows' or sys_platform == 'win32'
     # via bandit
     # via click
     # via pylint
@@ -30,7 +30,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via tqdm
 coverage==7.6.1
     # via pytest-cov
-dill==0.3.8
+dill==0.3.8 ; python_version >= '3.11'
     # via multiprocess
     # via pylint
 execnet==2.1.1
@@ -63,7 +63,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mpire==2.10.2
     # via cellophane
-multiprocess==0.70.16
+multiprocess==0.70.16 ; python_version >= '3.11'
     # via mpire
 mypy==0.991
 mypy-extensions==1.0.0
@@ -95,7 +95,7 @@ pygments==2.18.0
     # via mpire
     # via rich
 pylint==3.3.1
-pyreadline3==3.5.4 ; sys_platform == 'win32'
+pyreadline3==3.5.4 ; python_version >= '3.8' and sys_platform == 'win32'
     # via humanfriendly
 pytest==8.3.3
     # via pytest-clarity
@@ -113,7 +113,7 @@ pytest-profiling==1.7.0
 pytest-repeat==0.9.3
 pytest-subprocess==1.5.3
 pytest-xdist==3.6.1
-pywin32==306 ; sys_platform == 'win32'
+pywin32==306 ; platform_system == 'Windows'
     # via mpire
 pyyaml==6.0.2
     # via bandit
@@ -127,14 +127,14 @@ rich==13.8.1
     # via bandit
     # via pytest-clarity
     # via rich-click
-rich-click==1.8.3
+rich-click==1.8.9
     # via cellophane
 rpds-py==0.20.0
     # via jsonschema
     # via referencing
 ruamel-yaml==0.17.40
     # via cellophane
-ruamel-yaml-clib==0.2.8 ; python_full_version < '3.13' and platform_python_implementation == 'CPython'
+ruamel-yaml-clib==0.2.8 ; python_version < '3.13' and platform_python_implementation == 'CPython'
     # via ruamel-yaml
 semver==3.0.2
     # via cellophane

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,14 +14,14 @@ attrs==23.2.0
     # via cellophane
     # via jsonschema
     # via referencing
-click==8.1.7
+click==8.2.1
     # via cellophane
     # via rich-click
-colorama==0.4.6 ; sys_platform == 'win32'
+colorama==0.4.6 ; platform_system == 'Windows' or sys_platform == 'win32'
     # via click
     # via pytest
     # via tqdm
-dill==0.3.8
+dill==0.3.8 ; python_version >= '3.11'
     # via multiprocess
 frozendict==2.4.4
     # via cellophane
@@ -45,7 +45,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mpire==2.10.2
     # via cellophane
-multiprocess==0.70.16
+multiprocess==0.70.16 ; python_version >= '3.11'
     # via mpire
 packaging==24.1
     # via cellophane
@@ -59,13 +59,13 @@ psutil==5.9.8
 pygments==2.18.0
     # via mpire
     # via rich
-pyreadline3==3.5.4 ; sys_platform == 'win32'
+pyreadline3==3.5.4 ; python_version >= '3.8' and sys_platform == 'win32'
     # via humanfriendly
 pytest==8.3.3
     # via pytest-profiling
 pytest-profiling==1.7.0
     # via cellophane
-pywin32==306 ; sys_platform == 'win32'
+pywin32==306 ; platform_system == 'Windows'
     # via mpire
 questionary==2.0.1
     # via cellophane
@@ -74,14 +74,14 @@ referencing==0.35.1
     # via jsonschema-specifications
 rich==13.8.1
     # via rich-click
-rich-click==1.8.3
+rich-click==1.8.9
     # via cellophane
 rpds-py==0.20.0
     # via jsonschema
     # via referencing
 ruamel-yaml==0.17.40
     # via cellophane
-ruamel-yaml-clib==0.2.8 ; python_full_version < '3.13' and platform_python_implementation == 'CPython'
+ruamel-yaml-clib==0.2.8 ; python_version < '3.13' and platform_python_implementation == 'CPython'
     # via ruamel-yaml
 semver==3.0.2
     # via cellophane

--- a/src/cellophane/cfg/click_.py
+++ b/src/cellophane/cfg/click_.py
@@ -348,8 +348,8 @@ class TypedArray(InvertibleParamType):
     def invert(self, value: list) -> str:
         return value if isinstance(value, str) else ", ".join(repr(v) for v in value)
 
-    def get_metavar(self, param: click.Parameter) -> str | None:
-        del param  # Unused
+    def get_metavar(self, param: click.Parameter, ctx: click.Context | None = None) -> str | None:
+        del param, ctx  # Unused
         metavar = f"{self.name.upper()}"
         if (items_type := self.items.get("type")) is not None:
             metavar += f"[{items_type}]"
@@ -489,8 +489,8 @@ class FormattedString(click.ParamType):
             self.fail(f"Unable to convert '{value}' to string: {exc!r}", param, ctx)
         return _value
 
-    def get_metavar(self, param: click.Parameter) -> str | None:
-        del param
+    def get_metavar(self, param: click.Parameter, ctx: click.Context | None = None) -> str | None:
+        del param, ctx  # Unused
         metavar = f"{self.name.upper()}"
         if self.format_:
             metavar += f"[{self.format_}]"


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fix compatibility with click version 8.2.x

### The Why
Click 8.2.x changed the signature for `ParamType.get_metavar` to receive a `ctx` argument, which broke JSONSchema to Click parsing.

### The How
Add the `ctx` param to the `get_metavar` method for all `ParamType` subclasses.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
