### PR TITLE
tests: Include traceback in test report

### DIFF
--- a/src/cellophane/testing/hooks.py
+++ b/src/cellophane/testing/hooks.py
@@ -2,6 +2,7 @@ import logging
 import re
 import sys
 from pathlib import Path
+from traceback import format_exception
 from typing import Any, Iterable
 
 import pytest
@@ -40,9 +41,10 @@ def pytest_runtest_makereport(
     # but this is paraphrased from the pytest docs
     report: pytest.TestReport = yield  # type: ignore[misc, assignment]
     if invocation_ := item.funcargs.get("invocation"):
+        _traceback = "".join(format_exception(invocation_.exception))
         report.sections.append(("Args", " ".join(invocation_.args)))
         report.sections.append(("stdout/stderr", invocation_.output))
-        report.sections.append(("Exception", repr(invocation_.exception)))
+        report.sections.append(("Exception", _traceback))
     return report
 
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Include full traceback of potential exception in test report.

### The Why
Improve readability of test failures due to unexpected exceptions.

### The How
Replace a basic `repr` with a full `traceback.format_traceback` when generating test reports.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
