### PR TITLE
tests: Fix non-equal compare for regex and literal

### DIFF
--- a/src/cellophane/testing/util.py
+++ b/src/cellophane/testing/util.py
@@ -78,6 +78,11 @@ class regex:
             if not other.is_file():
                 raise ValueError("Path must be a file")
             return other.read_text() != self
+        elif isinstance(other, Iterable) and not isinstance(other, str):
+            return self != "\n".join(other)
+        elif not isinstance(other, str):
+            return self != repr(other)
+
         return any(pattern.search(other) is None for pattern in self.patterns)
 
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Handle more cases when comparing a non-string to a `regex` or `literal` in tests.

### The Why
Some cases with iterables and non-strings were poorly formatted in the test report.

### The How
Handle cases where the compared object is an `Iterable` but not a string by joining with newlines, or any other non-string class using `repr`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
