### PR TITLE
fix: Default pre-hook condition to 'unprocessed' to align with previo…

### DIFF
--- a/src/cellophane/modules/decorators.py
+++ b/src/cellophane/modules/decorators.py
@@ -111,7 +111,7 @@ def runner(
 
 def pre_hook(
     label: str | None = None,
-    condition: Literal["always", "unprocessed", "failed"] = "always",
+    condition: Literal["always", "unprocessed", "failed"] = "unprocessed",
     per: Literal["session", "runner"] = "session",
     before: str | DEPENDENCY_TYPE | None = None,
     after: str | DEPENDENCY_TYPE | None = None,

--- a/src/cellophane/modules/dispatcher.py
+++ b/src/cellophane/modules/dispatcher.py
@@ -160,6 +160,8 @@ def _run_pre_post_hooks(
         match hook.condition:
             case "always" if not (hook_samples := samples_):
                 hook_samples = samples_
+            case "unprocessed" if len(samples_) == 0:
+                hook_samples = samples_
             case "unprocessed" if not (hook_samples := samples_.unprocessed):
                 continue
             case "complete" if not (hook_samples := samples_.complete):

--- a/src/cellophane/modules/hook.py
+++ b/src/cellophane/modules/hook.py
@@ -189,7 +189,7 @@ class PreHook(_PrePostHook):
         self,
         func: NamedCallable,
         label: str | None = None,
-        condition: Literal["always", "unprocessed", "failed"] = "always",
+        condition: Literal["always", "unprocessed", "failed"] = "unprocessed",
         before: str | DEPENDENCY_TYPE | None = None,
         after: str | DEPENDENCY_TYPE | None = None,
         per: Literal["session", "sample", "runner"] = "session",

--- a/tests/test_integration/test_hook.py
+++ b/tests/test_integration/test_hook.py
@@ -136,7 +136,7 @@ class Test_hooks(BaseTest):
             "Running post_complete hook",
             "Running pre_per_runner hook",
             "Running post_per_runner_always hook",
-            "pre: ['fail_early', 'fail_x_a', 'fail_y_b', 'fail_y_c', 'pass_x_a', 'pass_x_b', 'pass_y_c']",
+            "pre: ['fail_x_a', 'fail_y_b', 'fail_y_c', 'pass_x_a', 'pass_x_b', 'pass_y_c']",
             "pre_always: ['fail_early', 'fail_x_a', 'fail_y_b', 'fail_y_c', 'pass_x_a', 'pass_x_b', 'pass_y_c']",
             "pre_unprocessed: ['fail_x_a', 'fail_y_b', 'fail_y_c', 'pass_x_a', 'pass_x_b', 'pass_y_c']",
             "pre_failed: ['fail_early']",
@@ -206,7 +206,7 @@ class Test_hooks(BaseTest):
     )
     def test_conditional_pre_hook(self, invocation: Invocation) -> None:
         assert invocation.logs == literal(
-            "Default hook executed for ['a', 'b']",
+            "Default hook executed for ['b']",
             "Unprocessed hook executed for ['b']",
             "Failed hook executed for ['a']",
             "Always hook executed for ['a', 'b']",


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Ensure pre-hooks don't execute for failed samples by default.

### The Why
Prior to `1.2.0`, pre-hooks would stop executing as soon as one threw an exception. This behavior changed as part of the dispatch overhaul, which added support for pre-hooks with condition `failed`, as the now default `always` condition would now also execute for failed samples (i.e. after another pre-hook threw an exception).

### The How
- Set the default pre-hook condition to `unprocessed`.
- Add a check so that pre-hooks with condition `unprocessed` will still execute if there are no samples.

This should better align with the previous behavior, and will require less rework of existing modules. 

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
