### PR TITLE
fix: Use UNSET sentinel for missing default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "Erik Demitz-Helin",email = "erik.demitz-helin@gu.se"}]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "click>=8.2.0,<9.0.0",
+    "click>=8.3.0,<9.0.0",
     "psutil>=5.9.4,<6.0.0",
     "rich-click>=1.8.9,<2.0.0",
     "humanfriendly>=10.0,<11.0",

--- a/src/cellophane/cfg/flag.py
+++ b/src/cellophane/cfg/flag.py
@@ -9,6 +9,7 @@ import rich_click as click
 from attrs import define, field, setters
 
 from .click_ import FORMATS, SCHEMA_TYPES, InvertibleParamType, click_type
+from click.parser import UNSET
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterable, SupportsFloat, Type
@@ -67,7 +68,7 @@ class Flag:
     format: FORMATS | None = field(default=None)
     pattern: str | None = field(default=None)
     description: str | None = field(default=None)
-    default: Any = field(default=None)
+    default: Any = field(default=UNSET)
     value: Any = field(default=None)
     enum: list | None = field(default=None)
     required: bool = field(default=False)
@@ -184,11 +185,11 @@ class Flag:
             (f"--{self.flag}/--{self.no_flag}" if self.type == "boolean" else f"--{self.flag}"),
             self.flag,
             type=type_,
-            default=True if self.type == "boolean" and default is None else default,
+            default=True if self.type == "boolean" and default is UNSET else default,
             required=self.required,
             help=self.description,
             show_default=(
-                (self.secret or default is None)
+                (self.secret or default is UNSET)
                 or (
                     type_.invert(default)  # type: ignore[arg-type]
                     if default and isinstance(type_, InvertibleParamType)

--- a/src/cellophane/cfg/schema.py
+++ b/src/cellophane/cfg/schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
+from click.parser import UNSET
 
 from ruamel.yaml import YAML, CommentedMap, CommentToken
 from ruamel.yaml.error import CommentMark
@@ -95,6 +96,9 @@ class Schema(Container):
                 else:
                     # Otherwise, use " to preserve whitespace
                     _default = DoubleQuotedScalarString(flag.default)
+            elif flag.default == UNSET:
+                # If the default is UNSET, use ~ to represent null
+                _default = None
             else:
                 # For all other types, use the default string representation
                 _default = flag.default

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=23.1.0,<24.0.0" },
-    { name = "click", specifier = ">=8.2.0,<9.0.0" },
+    { name = "click", specifier = ">=8.3.0,<9.0.0" },
     { name = "frozendict", specifier = ">=2.3.8,<3.0.0" },
     { name = "gitpython", specifier = ">=3.1.31,<4.0.0" },
     { name = "humanfriendly", specifier = ">=10.0,<11.0" },


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Use the `Sentinel.UNSET` instead of None for empty default values.

### The Why
Click version 8.3 no longer uses `None` to represent missing default values. This broke parsing required values, as `None` is now a valid default, so values were never considered missing.

### The How
- Replace `default=None` with `default=UNSET` (imported from `click.parser` references click._util.Sentinel.UNSET). As the sentinel lives in the private  `_util` namepsace, we may need to reconsider how it is accessed in the future, but for now this works.
- Pin the click dependency to 8.3.0 - 9.0.0 as this is where `Sentinel.UNSET` was introduced.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
