### PR TITLE
feat: Predicate as condition for hooks/runners

### DIFF
--- a/src/cellophane/modules/__init__.py
+++ b/src/cellophane/modules/__init__.py
@@ -11,6 +11,7 @@ from .hook import (
 )
 from .load import load
 from .runner_ import Runner
+from .predicate import SAMPLES_PREDICATE, EXCEPTION_PREDICATE, select_samples
 
 __all__ = [
     "ExceptionHook",
@@ -27,4 +28,7 @@ __all__ = [
     "exception_hook",
     "runner",
     "resolve_dependencies",
+    "SAMPLES_PREDICATE",
+    "EXCEPTION_PREDICATE",
+    "select_samples",
 ]

--- a/src/cellophane/modules/decorators.py
+++ b/src/cellophane/modules/decorators.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from cellophane.data import Samples
     from cellophane.modules.hook import DEPENDENCY_TYPE
     from cellophane.util import NamedCallable
+    from cellophane.modules import SAMPLES_PREDICATE, EXCEPTION_PREDICATE
 
 
 def output(
@@ -85,6 +86,7 @@ def output(
 def runner(
     label: str | None = None,
     split_by: str | None = None,
+    condition: SAMPLES_PREDICATE | None = None,
 ) -> Callable:
     """Decorator for creating a runner.
 
@@ -92,6 +94,8 @@ def runner(
     ----
         label (str | None): The label for the runner. Defaults to None.
         split_by (str | None): The attribute to link samples by. Defaults to None.
+        condition (SAMPLES_PREDICATE | None): An optional predicate function to
+            determine whether a sample should be processed by the runner.
 
     Returns:
     -------
@@ -100,10 +104,16 @@ def runner(
     """
 
     def wrapper(func: NamedCallable) -> Runner:
+        if condition is not None and not callable(condition):
+            raise ValueError(
+                f"Invalid condition for runner: '{condition}'. "
+                "Must be a callable predicate or None."
+            )
         return Runner(
             label=label,
             func=func,
             split_by=split_by,
+            condition=condition,
         )
 
     return wrapper
@@ -111,7 +121,7 @@ def runner(
 
 def pre_hook(
     label: str | None = None,
-    condition: Literal["always", "unprocessed", "failed"] = "always",
+    condition: Literal["always", "unprocessed", "failed"] | SAMPLES_PREDICATE = "always",
     per: Literal["session", "runner"] = "session",
     before: str | DEPENDENCY_TYPE | None = None,
     after: str | DEPENDENCY_TYPE | None = None,
@@ -121,6 +131,19 @@ def pre_hook(
     Args:
     ----
         label (str | None): The label for the pre-hook. Defaults to None.
+        condition (Literal["always", "unprocessed", "failed"] | SAMPLES_PREDICATE): The condition for
+            the pre-hook to execute.
+            - "always": The pre-hook will always execute.
+            - "unprocessed": The pre-hook will receive only unprocessed samples.
+            - "failed": The pre-hook will receive only failed samples.
+            - Or a custom predicate function that takes a sample, the samples, and the config,
+                and returns True if the sample should be processed by the pre-hook.
+            Defaults to "always".
+        per (Literal["session", "runner"]): The level at which the hook
+            will be executed.
+            - "session": The hook will be executed before any runners are executed.
+            - "runner": The hook will be executed before each runner is executed.
+            Defaults to "session".
         before (list[str] | Literal["all"] | None): List of pre-hooks guaranteed to
             execute after the resulting pre-hook. Defaults to an empty list.
         after (list[str] | Literal["all"] | None): List of pre-hooks guaratneed to
@@ -131,7 +154,11 @@ def pre_hook(
         Callable: The decorator function.
 
     """
-
+    if condition not in ("always", "unprocessed", "failed") and not callable(condition):
+        raise ValueError(
+            f"Invalid condition for pre-hook: '{condition}'. "
+            "Must be one of 'always', 'unprocessed', 'failed', or a callable predicate."
+        )
     def wrapper(func: NamedCallable) -> PreHook:
         return PreHook(
             label=label,
@@ -147,7 +174,7 @@ def pre_hook(
 
 def post_hook(
     label: str | None = None,
-    condition: Literal["always", "complete", "failed"] = "always",
+    condition: Literal["always", "complete", "failed"] | SAMPLES_PREDICATE = "always",
     per: Literal["session", "sample", "runner"] = "session",
     before: str | DEPENDENCY_TYPE | None = None,
     after: str | DEPENDENCY_TYPE | None = None,
@@ -157,7 +184,7 @@ def post_hook(
     Args:
     ----
         label (str | None): The label for the pre-hook. Defaults to None.
-        condition (Literal["always", "complete", "failed"]): The condition for
+        condition (Literal["always", "complete", "failed"] | SAMPLES_PREDICATE): The condition for
             the post-hook to execute.
             - "always": The post-hook will always execute.
             - "complete": The post-hook will recieve only completed samples.
@@ -179,9 +206,11 @@ def post_hook(
         Callable: The decorator function.
 
     """
-    if condition not in ["always", "complete", "failed"]:
-        raise ValueError(f"{condition=} must be one of 'always', 'complete', 'failed'")
-
+    if condition not in ("always", "complete", "failed") and not callable(condition):
+        raise ValueError(
+            f"Invalid condition for post-hook: '{condition}'. "
+            "Must be one of 'always', 'complete', 'failed', or a callable predicate."
+        )
     def wrapper(func: NamedCallable) -> PostHook:
         return PostHook(
             label=label,
@@ -198,6 +227,7 @@ def exception_hook(
     label: str | None = None,
     before: str | DEPENDENCY_TYPE | None = None,
     after: str | DEPENDENCY_TYPE | None = None,
+    condition: EXCEPTION_PREDICATE | None = None,
 ) -> Callable:
     """Decorator for creating an exception hook.
 
@@ -210,12 +240,19 @@ def exception_hook(
             execute after the resulting exception hook. Defaults to an empty list.
         after (list[str] | Literal["all"] | None): List of exception hooks guaranteed to
             execute before the resulting exception hook. Defaults to an empty list.
+        condition (Callable[[Exception], bool] | None): An optional predicate function
+            to determine whether an exception should be processed by the hook.
 
     Returns:
     -------
         Callable: The decorator function.
 
     """
+    if condition is not None and not callable(condition):
+        raise ValueError(
+            f"Invalid condition for exception hook: '{condition}'. "
+            "Must be a callable predicate or None."
+        )
 
     def wrapper(func: NamedCallable) -> ExceptionHook:
         return ExceptionHook(
@@ -223,6 +260,7 @@ def exception_hook(
             func=func,
             before=before,
             after=after,
+            condition=condition,
         )
 
     return wrapper

--- a/src/cellophane/modules/dispatcher.py
+++ b/src/cellophane/modules/dispatcher.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from functools import partial, wraps
 from logging import LoggerAdapter, getLogger
 from multiprocessing import Lock
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Callable, overload
 
 from mpire.exception import InterruptWorker
 from mpire.pool import WorkerPool
@@ -13,12 +13,13 @@ from cellophane.logs import handle_warnings, redirect_logging_to_queue
 
 from .checkpoint import Checkpoints
 from .hook import ExceptionHook, PostHook, PreHook
+from .predicate import select_samples
 
 if TYPE_CHECKING:
     from multiprocessing import Queue
     from multiprocessing.synchronize import Lock as LockType
     from pathlib import Path
-    from typing import Any, Callable, Literal, Sequence
+    from typing import Any, Literal, Sequence
     from uuid import UUID
 
     from cellophane.cfg import Config
@@ -157,27 +158,34 @@ def _run_pre_post_hooks(
     samples_ = deepcopy(samples)
 
     for hook in [h for h in hooks if isinstance(h, (PreHook, PostHook)) and (h.when, h.per) == (when, per)]:
-        match hook.condition:
-            case "always" if not (hook_samples := samples_):
-                hook_samples = samples_
-            case "unprocessed" if not (hook_samples := samples_.unprocessed):
-                continue
-            case "complete" if not (hook_samples := samples_.complete):
-                continue
-            case "failed" if not (hook_samples := samples_.failed):
-                continue
-
-        checkpoints = Checkpoints(
-            samples=hook_samples,
-            prefix=(
-                f"{hook.when}-hook.{hook.name}"
-                if checkpoint_suffix is None
-                else f"{hook.when}-hook.{hook.name}.{checkpoint_suffix}"
-            ),
-            workdir=config.workdir / config.tag,  # ty: ignore[unsupported-operator]
-            config=config,
-        )
         try:
+            match hook.condition:
+                case c if c not in ["always", "unprocessed", "complete", "failed"] and not callable(c):
+                    logger.warning(f"Hook '{hook.label}' has an invalid condition '{hook.condition}', skipping")
+                    continue
+                case "always":
+                    hook_samples = samples_
+                case "unprocessed" if not (hook_samples := samples_.unprocessed):
+                    continue
+                case "complete" if not (hook_samples := samples_.complete):
+                    continue
+                case "failed" if not (hook_samples := samples_.failed):
+                    continue
+                case predicate if callable(predicate) and not (hook_samples := select_samples(samples_, config, predicate)):
+                    logger.debug(f"No samples satisfy condition for {hook.when}-hook '{hook.label}', skipping")
+                    continue
+
+            checkpoints = Checkpoints(
+                samples=hook_samples,
+                prefix=(
+                    f"{hook.when}-hook.{hook.name}"
+                    if checkpoint_suffix is None
+                    else f"{hook.when}-hook.{hook.name}.{checkpoint_suffix}"
+                ),
+                workdir=config.workdir / config.tag,
+                config=config,
+            )
+
             samples_ |= hook(
                 samples=hook_samples,
                 config=config,
@@ -216,6 +224,9 @@ def _run_exception_hooks(
 ) -> None:
     for hook in [h for h in hooks if isinstance(h, ExceptionHook)]:
         try:
+            if callable(hook.condition) and not hook.condition(exception, config=config):
+                logger.debug(f"Exception '{exception!r}' does not satisfy condition for exception hook '{hook.label}', skipping")
+                continue
             hook(
                 exception=exception,
                 config=config,
@@ -283,7 +294,11 @@ def _start_runners(
                 for r in runners
                 for g, s in (samples.split(by=r.split_by) if r.split_by else [(None, samples)])
             ):
-                workdir = config.workdir / config.tag / runner_.name  # ty: ignore[unsupported-operator]
+                if callable(runner_.condition) and not (samples_ := select_samples(samples_, config, runner_.condition)):
+                    logger.debug(f"No samples satisfy condition for runner '{runner_.label}', skipping")
+                    continue
+
+                workdir = config.workdir / config.tag / runner_.name
                 if runner_.split_by is not None:
                     workdir /= str(group or "unknown")
                 runner_lock = Lock()

--- a/src/cellophane/modules/hook.py
+++ b/src/cellophane/modules/hook.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from cellophane.cleanup import Cleaner, DeferredCleaner
     from cellophane.executors import Executor
     from cellophane.util import NamedCallable, Timestamp
+    from cellophane.modules import SAMPLES_PREDICATE, EXCEPTION_PREDICATE
 
 
 class _AFTER_ALL: ...
@@ -35,7 +36,7 @@ class _BaseHook:
     label: str
     func: NamedCallable
     when: Literal["pre", "post", "exception"]
-    condition: Literal["always", "complete", "unprocessed", "failed"]
+    condition: Literal["always", "complete", "unprocessed", "failed"] | EXCEPTION_PREDICATE | SAMPLES_PREDICATE
     before: DEPENDENCY_TYPE
     after: DEPENDENCY_TYPE
     per: Literal["session", "sample", "runner"] = "session"
@@ -45,7 +46,7 @@ class _BaseHook:
         func: NamedCallable,
         when: Literal["pre", "post", "exception"],
         label: str | None = None,
-        condition: Literal["always", "complete", "unprocessed", "failed"] = "always",
+        condition: Literal["always", "complete", "unprocessed", "failed"] | EXCEPTION_PREDICATE | SAMPLES_PREDICATE = "always",
         before: str | DEPENDENCY_TYPE | None = None,
         after: str | DEPENDENCY_TYPE | None = None,
         per: Literal["session", "sample", "runner"] = "session",
@@ -130,7 +131,7 @@ class _PrePostHook(_BaseHook):
         func: NamedCallable,
         when: Literal["pre", "post"],
         label: str | None = None,
-        condition: Literal["always", "complete", "unprocessed", "failed"] = "always",
+        condition: Literal["always", "complete", "unprocessed", "failed"] | SAMPLES_PREDICATE = "always",
         before: str | DEPENDENCY_TYPE | None = None,
         after: str | DEPENDENCY_TYPE | None = None,
         per: Literal["session", "sample", "runner"] = "session",
@@ -189,7 +190,7 @@ class PreHook(_PrePostHook):
         self,
         func: NamedCallable,
         label: str | None = None,
-        condition: Literal["always", "unprocessed", "failed"] = "always",
+        condition: Literal["always", "unprocessed", "failed"] | SAMPLES_PREDICATE = "unprocessed",
         before: str | DEPENDENCY_TYPE | None = None,
         after: str | DEPENDENCY_TYPE | None = None,
         per: Literal["session", "sample", "runner"] = "session",
@@ -214,7 +215,7 @@ class PostHook(_PrePostHook):
         self,
         func: NamedCallable,
         label: str | None = None,
-        condition: Literal["always", "complete", "failed"] = "always",
+        condition: Literal["always", "complete", "failed"] | SAMPLES_PREDICATE = "always",
         before: str | DEPENDENCY_TYPE | None = None,
         after: str | DEPENDENCY_TYPE | None = None,
         per: Literal["session", "sample", "runner"] = "session",
@@ -234,7 +235,7 @@ class ExceptionHook(_BaseHook):
     """Cellophane exception-hook."""
 
     when: Literal["exception"]
-    condition: Literal["always"]
+    condition: Literal["always"] | EXCEPTION_PREDICATE
 
     def __init__(
         self,
@@ -242,12 +243,13 @@ class ExceptionHook(_BaseHook):
         label: str | None = None,
         before: str | DEPENDENCY_TYPE | None = None,
         after: str | DEPENDENCY_TYPE | None = None,
+        condition: EXCEPTION_PREDICATE | None = None,
     ) -> None:
         super().__init__(
             func,
             when="exception",
             label=label,
-            condition="always",
+            condition=condition or "always",
             before=before,
             after=after,
             per="session",
@@ -272,7 +274,6 @@ class ExceptionHook(_BaseHook):
             timestamp=timestamp,
             dispatcher=dispatcher,
         )
-
 
 def resolve_dependencies(
     hooks: list[PreHook | PostHook | ExceptionHook],

--- a/src/cellophane/modules/predicate.py
+++ b/src/cellophane/modules/predicate.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+from copy import deepcopy
+
+if TYPE_CHECKING:
+    from cellophane.data import Sample, Samples
+    from cellophane.cfg import Config
+    from typing import TypeVar
+
+    S = TypeVar("S", bound=Sample)
+
+class SAMPLES_PREDICATE(Protocol):
+    def __call__(self, sample: Sample, /, samples: Samples, config: Config) -> bool: ...
+
+class EXCEPTION_PREDICATE(Protocol):
+    def __call__(self, exception: BaseException, config: Config) -> bool: ...
+
+def select_samples(samples: Samples[S], config: Config, predicate: SAMPLES_PREDICATE) -> Samples[S]:
+    """Selects samples based on a predicate function.
+
+    Args:
+    ----
+        samples (Samples[S]): The samples to be filtered.
+        config (Config): The configuration object.
+        predicate (PREDICATE): A predicate function that takes a sample, the samples, and the config,
+            and returns True if the sample should be included in the result.
+
+    Returns:
+    -------
+        Samples[S]: A new Samples object containing the selected samples.
+    """
+    instance = deepcopy(samples)
+    instance.data = [
+        sample
+        for sample in samples
+        if predicate(sample, samples=samples, config=config)
+    ]
+
+    return instance

--- a/src/cellophane/modules/runner_.py
+++ b/src/cellophane/modules/runner_.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from cellophane.cfg import Config
     from cellophane.executors import Executor
-    from cellophane.modules import Dispatcher
+    from cellophane.modules import Dispatcher, SAMPLES_PREDICATE
     from cellophane.util import Timestamp
 
 def _resolve_outputs(
@@ -101,12 +101,14 @@ class Runner:
     split_by: str | None
     func: Callable
     main: Callable[..., Samples | None]
+    condition: SAMPLES_PREDICATE | None
 
     def __init__(
         self,
         func: Callable,
         label: str | None = None,
         split_by: str | None = None,
+        condition: SAMPLES_PREDICATE | None = None,
     ) -> None:
         self.__name__ = func.__name__  # type: ignore[attr-defined]
         self.__qualname__ = func.__qualname__  # type: ignore[attr-defined]
@@ -115,6 +117,7 @@ class Runner:
         self.main = staticmethod(func)
         self.label = label or self.__name__
         self.split_by = split_by
+        self.condition = condition
         super().__init_subclass__()
 
     def __call__(

--- a/tests/test_integration/test_hook.py
+++ b/tests/test_integration/test_hook.py
@@ -213,6 +213,160 @@ class Test_hooks(BaseTest):
         )
 
     @mark.override(
+        args=[*args, "--samples_file samples.yaml"],
+        structure={
+            "samples.yaml": """
+                - id: x_1
+                  a: x
+                  files:
+                  - input/DUMMY.txt
+                - id: x_2
+                  a: x
+                  files:
+                  - input/DUMMY.txt
+                - id: x_3
+                  a: x
+                  files:
+                  - input/DUMMY.txt
+                - id: y_1
+                  a: y
+                  files:
+                  - input/DUMMY.txt
+                - id: y_2
+                  a: y
+                  files:
+                  - input/DUMMY.txt
+                - id: y_3
+                  a: y
+                  files:
+                  - input/DUMMY.txt
+            """,
+            "input/DUMMY.txt": "DUMMY",
+            "schema.yaml": """
+                type: object
+                properties:
+                    foo:
+                        type: string
+                        default: x
+            """,
+
+            "modules/a.py": """
+                from cellophane import pre_hook, post_hook, Samples, Sample
+
+                class TestSamples(Samples):
+                    foo: str = "y"
+
+                class TestSample(Sample):
+                    a: str | None = None
+
+                @pre_hook(condition=lambda s, **_: s.a == "x")
+                def pre_hook_x(samples, logger, **_):
+                    logger.info(f"pre_hook_x executed for {[s.id for s in samples]}")
+
+                @pre_hook(condition=lambda s, **_: s.a == "y")
+                def pre_hook_y(samples, logger, **_):
+                    logger.info(f"pre_hook_y executed for {[s.id for s in samples]}")
+
+                @pre_hook(condition=lambda s, config, **_: s.a == config.foo)
+                def pre_hook_config(samples, logger, **_):
+                    logger.info(f"pre_hook_config executed for {[s.id for s in samples]}")
+
+                @pre_hook(condition=lambda s, samples, **_: s.a == samples.foo)
+                def pre_hook_samples(samples, logger, **_):
+                    logger.info(f"pre_hook_samples executed for {[s.id for s in samples]}")
+
+                @pre_hook(condition=lambda s, **_: False)
+                def pre_hook_false(samples, logger, **_):
+                    logger.info(f"pre_hook_false executed for {[s.id for s in samples]}")
+
+
+                @post_hook(condition=lambda s, **_: s.a == "x")
+                def post_hook_x(samples, logger, **_):
+                    logger.info(f"post_hook_x executed for {[s.id for s in samples]}")
+
+                @post_hook(condition=lambda s, **_: s.a == "y")
+                def post_hook_y(samples, logger, **_):
+                    logger.info(f"post_hook_y executed for {[s.id for s in samples]}")
+
+                @post_hook(condition=lambda s, config, **_: s.a == config.foo)
+                def post_hook_config(samples, logger, **_):
+                    logger.info(f"post_hook_config executed for {[s.id for s in samples]}")
+
+                @post_hook(condition=lambda s, samples, **_: s.a == samples.foo)
+                def post_hook_samples(samples, logger, **_):
+                    logger.info(f"post_hook_samples executed for {[s.id for s in samples]}")
+
+                @post_hook(condition=lambda s, **_: False)
+                def post_hook_false(samples, logger, **_):
+                    logger.info(f"post_hook_false executed for {[s.id for s in samples]}")
+            """
+        }
+    )
+    def test_predicate_pre_post_hooks(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal(
+            "pre_hook_x executed for ['x_1', 'x_2', 'x_3']",
+            "pre_hook_y executed for ['y_1', 'y_2', 'y_3']",
+            "pre_hook_config executed for ['x_1', 'x_2', 'x_3']",
+            "pre_hook_samples executed for ['y_1', 'y_2', 'y_3']",
+            "No samples satisfy condition for pre-hook 'pre_hook_false', skipping",
+            "post_hook_x executed for ['x_1', 'x_2', 'x_3']",
+            "post_hook_y executed for ['y_1', 'y_2', 'y_3']",
+            "post_hook_config executed for ['x_1', 'x_2', 'x_3']",
+            "post_hook_samples executed for ['y_1', 'y_2', 'y_3']",
+            "No samples satisfy condition for post-hook 'post_hook_false', skipping",
+        )
+
+
+    @mark.override(
+        args=[*args, "--samples_file samples.yaml"],
+        structure={
+            "samples.yaml": """
+                - id: x
+                  files:
+                  - input/DUMMY.txt
+            """,
+            "input/DUMMY.txt": "DUMMY",
+            "schema.yaml": """
+                type: object
+                properties:
+                    foo:
+                        type: string
+                        default: x
+            """,
+
+            "modules/a.py": """
+                from cellophane import exception_hook, pre_hook
+
+                class DummyException(Exception): ...
+
+                @exception_hook(condition=lambda e, **_: isinstance(e, DummyException))
+                def exception_hook_a(exception, logger, **_):
+                    logger.info(f"exception_hook_a executed for exception: {exception!r}")
+
+                @exception_hook(condition=lambda e, **_: isinstance(e, ValueError))
+                def exception_hook_b(exception, logger, **_):
+                    logger.info(f"exception_hook_b executed for exception: {exception!r}")
+
+                @exception_hook(condition=lambda e, config, **_: config.foo == "x")
+                def exception_hook_config(exception, logger, **_):
+                    logger.info(f"exception_hook_config executed for exception: {exception!r}")
+
+                @pre_hook(before="all")
+                def pre_hook_x(**_):
+                    raise DummyException("DUMMY")
+
+
+            """
+        }
+    )
+    def test_predicate_exception_hooks(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal(
+            "exception_hook_a executed for exception: DummyException('DUMMY')",
+            "exception_hook_config executed for exception: DummyException('DUMMY')",
+            "Exception 'DummyException('DUMMY')' does not satisfy condition for exception hook 'exception_hook_b', skipping"
+        )
+
+    @mark.override(
         structure={
             "modules/a.py": """
                 from cellophane import exception_hook
@@ -742,6 +896,20 @@ class Test_hooks(BaseTest):
     @mark.override(
         structure={
             "modules/a.py": """
+                from cellophane import pre_hook
+
+                @pre_hook(condition="INVALID")
+                def a(**_): ...
+            """
+        },
+    )
+    def test_pre_hook_invalid_condition(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal("Unable to import module 'a': ValueError(\"Invalid condition for pre-hook: 'INVALID'. Must be one of 'always', 'unprocessed', 'failed', or a callable predicate.\")")
+
+
+    @mark.override(
+        structure={
+            "modules/a.py": """
                 from cellophane import post_hook
 
                 @post_hook(condition="INVALID")
@@ -749,7 +917,19 @@ class Test_hooks(BaseTest):
             """
         },
     )
-    def test_hook_invalid_condition(self, invocation: Invocation) -> None:
-        assert invocation.logs == literal(
-            "Unable to import module 'a': ValueError(\"condition='INVALID' must be one of 'always', 'complete', 'failed'\")"
-        )
+    def test_post_hook_invalid_condition(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal("Unable to import module 'a': ValueError(\"Invalid condition for post-hook: 'INVALID'. Must be one of 'always', 'complete', 'failed', or a callable predicate.\")")
+
+
+    @mark.override(
+        structure={
+            "modules/a.py": """
+                from cellophane import exception_hook
+
+                @exception_hook(condition="INVALID")
+                def a(**_): ...
+            """
+        },
+    )
+    def test_exception_hook_invalid_condition(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal("Unable to import module 'a': ValueError(\"Invalid condition for exception hook: 'INVALID'. Must be a callable predicate or None.\")")

--- a/tests/test_integration/test_runner.py
+++ b/tests/test_integration/test_runner.py
@@ -157,3 +157,88 @@ class Test_runners(BaseTest):
             "Runner a: ['a', 'b']",
             "Runner a: ['c', 'd']",
         )
+
+    @mark.override(
+        args=[*args, "--x"],
+        structure={
+            **structure,
+            "schema.yaml": """
+                type: object
+                properties:
+                    x:
+                        type: boolean
+                        default: false
+                    y:
+                        type: boolean
+                        default: false
+            """,
+            "modules/a.py": """
+                from cellophane import runner, Sample
+
+                class TestSample(Sample):
+                    some_key: int = 0
+
+                @runner(condition=lambda s, **_: s.some_key == 1)
+                def runner_1(samples, logger, **_):
+                    logger.info(f"runner_1: {[str(s) for s in samples]}")
+
+                @runner(condition=lambda s, **_: s.some_key == 2)
+                def runner_2(samples, logger, **_):
+                    logger.info(f"runner_2: {[str(s) for s in samples]}")
+
+                @runner(condition=lambda s, config, **_: config.x)
+                def runner_config_x(samples, logger, **_):
+                    logger.info("runner_config_x was invoked")
+
+                @runner(condition=lambda s, config, **_: False)
+                def runner_config_y(samples, logger, **_):
+                    logger.info("runner_config_y was invoked")
+            """,
+            "samples.yaml": """
+                - id: a
+                  some_key: 1
+                  files: ["input/a.txt"]
+                - id: b
+                  some_key: 1
+                  files: ["input/a.txt"]
+                - id: c
+                  some_key: 2
+                  files: ["input/a.txt"]
+                - id: d
+                  some_key: 2
+                  files: ["input/a.txt"]
+            """,
+        }
+    )
+    def test_runner_predicate(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal(
+            "runner_1: ['a', 'b']",
+            "runner_2: ['c', 'd']",
+            "runner_config_x was invoked",
+            "No samples satisfy condition for runner 'runner_config_y', skipping"
+        )
+
+        assert invocation.logs != literal(
+            "No samples satisfy condition for runner 'runner_config_x', skipping"
+            "runner_config_y was invoked",
+        )
+
+    @mark.override(
+        structure={
+            **structure,
+            "modules/a.py": """
+                from cellophane import runner
+
+                @runner(condition="INVALID")
+                def runner_1(samples, logger, **_):
+                    logger.info(f"runner_1 has been invoked")
+
+            """,
+            "samples.yaml": """
+                - id: a
+                  files: ["input/a.txt"]
+            """,
+        }
+    )
+    def test_runner_invalid_condition(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal("Unable to import module 'a': ValueError(\"Invalid condition for runner: 'INVALID'. Must be a callable predicate or None.\")")


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Allow specifying predicates as conditions for hooks/runners.

### The Why
The current set of conditions ("always", "failed", "complete", "unprocessed") is quite limited, and there are many use-cases where it would be more helpful to filter the samples via a predicate.

### The How
- Adds the option to use a predicate function to filter samples for pre- and post-hooks. The function will be called for each sample and passed the full `Samples` object and current config as kwargs.
- Adds the option to use a predicate function to filter exceptions to exception hooks. The function will called withe hte raised exception and will be passed the current config as a kwarg.
- If the predicate returns `False` for a given sample/exception then the hook/runner will not be called for it.
- For pre/post hooks and runners, if no samples match the predicate, the runner/hook will not be called at all.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
