### PR TITLE
fix: Typing fixes for predicates

### DIFF
--- a/src/cellophane/modules/predicate.py
+++ b/src/cellophane/modules/predicate.py
@@ -8,27 +8,28 @@ if TYPE_CHECKING:
     from cellophane.cfg import Config
     from typing import TypeVar
 
-    S = TypeVar("S", bound=Sample)
+    SAMPLE = TypeVar("SAMPLE", bound=Sample)
+    SAMPLES = TypeVar("SAMPLES", bound=Samples)
 
 class SAMPLES_PREDICATE(Protocol):
-    def __call__(self, sample: Sample, /, samples: Samples, config: Config) -> bool: ...
+    def __call__(self, sample: SAMPLE, /, samples: SAMPLES, config: Config) -> bool: ...
 
 class EXCEPTION_PREDICATE(Protocol):
     def __call__(self, exception: BaseException, config: Config) -> bool: ...
 
-def select_samples(samples: Samples[S], config: Config, predicate: SAMPLES_PREDICATE) -> Samples[S]:
+def select_samples(samples: SAMPLES, config: Config, predicate: SAMPLES_PREDICATE) -> SAMPLES:
     """Selects samples based on a predicate function.
 
     Args:
     ----
-        samples (Samples[S]): The samples to be filtered.
+        samples (SAMPLES): The samples to be filtered.
         config (Config): The configuration object.
         predicate (PREDICATE): A predicate function that takes a sample, the samples, and the config,
             and returns True if the sample should be included in the result.
 
     Returns:
     -------
-        Samples[S]: A new Samples object containing the selected samples.
+        SAMPLES: A new Samples object containing the selected samples.
     """
     instance = deepcopy(samples)
     instance.data = [


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fixes typing in predicates

### The Why
Type checking SAMPLE_PREDICATE failed when a predicate was passed with a Sample/Samples subclass

### The How
Use the `SAMPLE`/`SAMPLES` TypeVars for type hinting the protocols, to allow subclasses in predicate signatures.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
