### PR TITLE
Ensure deprecation warnings are logged

### DIFF
--- a/src/cellophane/executors/executor.py
+++ b/src/cellophane/executors/executor.py
@@ -210,7 +210,7 @@ class Executor:
                     "These arguments define 'pathlib.Path' objects pointing where cellophane expects an executor to "
                     "write the standard output and error streams of the job. In the next major release of cellophane, "
                     "this will raise an exception.",
-                    category=PendingDeprecationWarning,
+                    category=DeprecationWarning,
                 )
 
             self.target(*_args, **kwargs)  # type: ignore[arg-type]

--- a/src/cellophane/logs/util.py
+++ b/src/cellophane/logs/util.py
@@ -40,7 +40,7 @@ def _showwarning(showwarning_orig: Callable) -> Callable:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if category is not UserWarning:
+        if category not in (UserWarning, DeprecationWarning):
             showwarning_orig(message, category, *args, **kwargs)
             return
 
@@ -59,7 +59,7 @@ def _showwarning(showwarning_orig: Callable) -> Callable:
             func=stack[2].function,
             args=(),
             exc_info=None,
-            extra={"label": "warnings"},
+            extra={"label": "cellophane"},
         )
         logger.handle(record)
 
@@ -68,6 +68,7 @@ def _showwarning(showwarning_orig: Callable) -> Callable:
 
 def handle_warnings() -> None:
     _warnings_showwarning = warnings.showwarning
+    warnings.filterwarnings("once", category=DeprecationWarning)
     warnings.showwarning = _showwarning(_warnings_showwarning)  # ty: ignore[invalid-assignment]
 
 

--- a/src/cellophane/src.py
+++ b/src/cellophane/src.py
@@ -6,7 +6,7 @@ from warnings import warn
 warn(
     "Importing from cellophane.src will be deprecated in a future version of cellophane. "
     "References to 'cellophane.src' should be replaced with 'cellophane'",
-    category=PendingDeprecationWarning,
+    category=DeprecationWarning,
 )
 
 __path__ = [str(Path(__file__).parent)]

--- a/src/cellophane/testing/legacy.py
+++ b/src/cellophane/testing/legacy.py
@@ -73,7 +73,7 @@ def parametrize_from_yaml(paths: list[Path]) -> Callable:
         "YAML test definitions will be removed in a future release. "
         "Please check the documentation for more information regarding the new "
         "testing API.",
-        DeprecationWarning,
+        category=DeprecationWarning,
         stacklevel=2,
     )
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Ensure deprecation warnings are logged.

### The Why
Currently, warnings deprecated features are issued as `PendingDeprecationWarning`, but they are filtered by the default warning filters, so our `showwarnings` handler doesn't show them in the logs. 

This fix makes sure the warnings show up as `WARNING` log messages so the user is notified when using deprecated features.

### The How
- Replace all `PendingDeprecationWarning` with `DeprecationWarning` as per the docs.
- Use `warnings.filterwarnings` to remove the `DeprecationWarning` filter when setting up the `showwarnings` handler.
- Update the logging filter to also show `DeprecationWarning` as a log message

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
