### PR TITLE
Deprecate sample files validation

### DIFF
--- a/src/cellophane/cellophane.py
+++ b/src/cellophane/cellophane.py
@@ -187,13 +187,6 @@ def _main(
         cleaner=cleaner,
     )
 
-    # Validate sample files
-    # FIXME: Make validation configurable
-    for sample in samples:
-        if sample not in samples.with_files:
-            logger.warning(f"Sample {sample} will be skipped as it has no files")
-            sample.fail("Missing files")
-
     # Start runners for unprocessed samples and mergeback failed samples after
     samples = (
         dispatcher.start_runners(

--- a/src/cellophane/modules/decorators.py
+++ b/src/cellophane/modules/decorators.py
@@ -6,15 +6,17 @@ from cellophane.data import OutputGlob
 
 from .hook import ExceptionHook, PostHook, PreHook
 from .runner_ import Runner
+from warnings import warn
 
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Callable, Literal
 
-    from cellophane.data import Samples
+    from cellophane.data import Samples, Sample
     from cellophane.modules.hook import DEPENDENCY_TYPE
     from cellophane.util import NamedCallable
     from cellophane.modules import SAMPLES_PREDICATE, EXCEPTION_PREDICATE
+    from cellophane.cfg import Config
 
 
 def output(
@@ -82,11 +84,26 @@ def output(
 
     return wrapper
 
+def _files_predicate(sample: Sample, /, samples: Samples, config: Config) -> bool:
+    warn(
+        "Skipping and failing samples with no files is deprecated and will be removed in a future cellophane version. "
+        "If you rely on this behavior, please implement a custom runner predicate and fail samples in a pre-hook.",
+        category=DeprecationWarning,
+    )
+    if sample.files:
+        return True
+    else:
+        # NOTE: Mutating samples in a predicate is not recommended, but we will do it here for backwards compatibility.
+        # If you want to emulate this behavior after this is removed, you can implement a pre-hook that fails samples
+        # with no files instead.
+        warn(f"Sample {sample} will be skipped as it has no files")
+        sample.fail("Missing files")
+        return False
 
 def runner(
     label: str | None = None,
     split_by: str | None = None,
-    condition: SAMPLES_PREDICATE | None = None,
+    condition: SAMPLES_PREDICATE | None = _files_predicate,
 ) -> Callable:
     """Decorator for creating a runner.
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Deprecate the hard requirement for samples having files before starting runners.

The behavior has been implemented as a predicate to notify about the deprecation whilst remaining backwards compatible. Passing `condition=None` to the `runner` decorator (or using a custom predicate) will disable this behavior.

### The Why
- Not all wrappers require samples to actually have files.
- The behavior can be fully replicated with a predicate and hooks.
- Predicates allows for much more customizable filtering for runners.

### The How
- Move the `sample.files` validation to a temporary runner predicate and supply it as default to the `runner` decorator.
- Show a deprecation warning when the predicate is used.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
