### PR TITLE
Add test for warning logging

### DIFF
--- a/tests/test_integration/test_logs.py
+++ b/tests/test_integration/test_logs.py
@@ -1,0 +1,24 @@
+from cellophane.testing import BaseTest, Invocation, literal
+from pytest import mark
+
+class Test_logs(BaseTest):
+    args = ["--workdir out"]
+
+    @mark.override(
+        structure={
+            "modules/a.py": """
+                from cellophane import pre_hook
+                from warnings import warn
+
+                @pre_hook()
+                def test_warning(samples, logger, **_):
+                    warn("USER WARNING")
+                    warn("DEPRECATION WARNING", DeprecationWarning)
+            """,
+        }
+    )
+    def test_module_handle_warnings(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal(
+            "USER WARNING",
+            "DEPRECATION WARNING",
+        )


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Add a test to verify warnings are logged.

### The Why
A test was not included in the fix for warning logging.

### The How
Wrote a test that verifies `UserWarnings` and `DeprecationWarnings` are actually logged.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
