### PR TITLE
Ensure imported Sample/Samples mixins are not loaded twice

### DIFF
--- a/src/cellophane/modules/load.py
+++ b/src/cellophane/modules/load.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio as aio
 import sys
 from importlib.util import module_from_spec, spec_from_file_location
+from inspect import getfile
 from site import addsitedir
 from typing import TYPE_CHECKING
 
@@ -48,9 +49,9 @@ async def _async_load(file: Path) -> MODULE_CONTENTS:
     for obj in [getattr(module, a) for a in dir(module)]:
         if is_instance_or_subclass(obj, (PreHook, PostHook, ExceptionHook)):
             hooks.append(obj)
-        elif is_instance_or_subclass(obj, Sample):
+        elif is_instance_or_subclass(obj, Sample) and getfile(obj) == str(file):
             sample_mixins.append(obj)
-        elif is_instance_or_subclass(obj, Samples):
+        elif is_instance_or_subclass(obj, Samples) and getfile(obj) == str(file):
             samples_mixins.append(obj)
         elif is_instance_or_subclass(obj, Runner):
             runners.append(obj)

--- a/tests/test_integration/test_module_load.py
+++ b/tests/test_integration/test_module_load.py
@@ -147,3 +147,34 @@ class Test_module_load(BaseTest):
     def test_module_add_log_handler(self, invocation: Invocation) -> None:
         assert "SHOULD BE SUPPRESSED" not in invocation.logs
         assert invocation.exit_code == 0
+
+
+    @mark.override(
+        args=[*args, "--samples_file", "samples.yml"],
+        structure={
+            "samples.yml": """
+            - id: a
+            """,
+
+            "modules/dummy_a.py": """
+            from cellophane import Sample
+
+            class SampleA(Sample): ...
+            """,
+
+            "modules/dummy_b.py": """
+            from .dummy_a import SampleA
+            """,
+
+            "modules/test.py": """
+            from cellophane import runner
+
+            @runner(condition=None)
+            def test_runner(logger, **_):
+                logger.info("RUNNER EXECUTED")
+            """,
+        }
+    )
+    def test_cross_module_import(self, invocation: Invocation) -> None:
+        assert invocation.logs == literal("RUNNER EXECUTED")
+        assert invocation.exit_code == 0


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fixes issues when a module imports a `Sample`/`Samples` mixin from another module (eg. for type checking).

### The Why
Previously, either:

A) A duplicate base class error would be thrown when merging the sample classes
B) An exception would be thrown during pickling that the classes are no longer the same.

While there aren't many legitimate use-cases for importing mixins between modules (for type checking you could just use `if TYPE_CHECKING`), this behavior was a bit unexpected and difficult to diagnose.

### The How
The module loader now checks if the file a mixin is defined in matches the file that is currently being loaded from. If not, they are silently ignored.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
